### PR TITLE
Update README.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ We don't use GitHub as a support forum. For any usage questions that are not spe
 
 # Reporting Issues
 
-If you encounter a bug with the iOS Watson SDK, please submit a detailed [issue](https://github.com/IBM-MIL/Watson-iOS-SDK/issues) so that it can be addressed quickly. We always appreciate a well-written, thorough bug report.
+If you encounter a bug with the Watson Developer Cloud iOS SDK, please submit a detailed [issue](https://github.com/IBM-MIL/Watson-iOS-SDK/issues) so that it can be addressed quickly. We always appreciate a well-written, thorough bug report.
 
 Please check that the project issues database doesn't already include that problem or suggestion before submitting an issue. If you find a match, add a quick "+1" or "I have this problem too." Doing so helps prioritize the most common problems and requests.
 

--- a/Quickstart.md
+++ b/Quickstart.md
@@ -6,7 +6,7 @@ This is a quick walkthrough to demonstrate how to create an iOS app that uses Wa
 
 Before beginning to create the iOS application, make sure you set up a BlueMix application and create a Text To Speech service. First, sign up for a Bluemix account. Next, create a new Bluemix application, it can either be Node JS or Liberty application (it does not matter in this example since we will not be deploying any server-side code). Next, setup an instance of the Watson Text to Speech service for that application. When a service gets bound to a Bluemix application, new credentials are automatically generated for making calls to the service. These credentials will be used as part of this getting started guide, and can be found once the service is started by clicking on the “Show Credentials” link on the service. For more information about creating Bluemix applications and attaching Bluemix and Watson services read [Bluemix getting started](https://developer.ibm.com/bluemix/#gettingstarted).
 
-In addition, this quick guide uses Carthage to fetch the Watson iOS SDK and its dependencies. [Carthage](https://github.com/Carthage/Carthage) provides instruction for [Installing Carthage](https://github.com/Carthage/Carthage#installing-carthage).
+In addition, this quick guide uses Carthage to fetch the Watson Developer Cloud iOS SDK and its dependencies. [Carthage](https://github.com/Carthage/Carthage) provides instruction for [Installing Carthage](https://github.com/Carthage/Carthage#installing-carthage).
 
 
 ###Create a Text to Speech App
@@ -120,4 +120,4 @@ github "watson-developer-cloud/ios-sdk"
 
 You can review the different voices and languages [here](https://github.com/watson-developer-cloud/ios-sdk#text-to-speech).
 
-You can download all the source code for the Watson iOS SDK [here](https://github.com/watson-developer-cloud/ios-sdk).
+You can download all the source code for the Watson Developer Cloud iOS SDK [here](https://github.com/watson-developer-cloud/ios-sdk).

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# Watson iOS SDK
+# Watson Developer Cloud iOS SDK
 
 [![Build Status](https://travis-ci.org/watson-developer-cloud/ios-sdk.svg?branch=develop)](https://travis-ci.org/watson-developer-cloud/ios-sdk)
 [![Carthage Compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 
-The Watson iOS SDK is a collection of services to allow developers to quickly add Watson Cognitive Computing services to their Swift iOS applications.
+The Watson Developer Cloud iOS SDK is a collection of services to allow developers to quickly add Watson Cognitive Computing services to their Swift iOS applications.
 
 Visit our [Quickstart Guide](Quickstart.md) to build your first iOS app with Watson!
 
-> *The Watson iOS SDK is currently in beta.*
+> *The Watson Developer Cloud iOS SDK is currently in beta.*
 
 ## Table of Contents
 * [Installation](#installation)
@@ -29,7 +29,7 @@ Visit our [Quickstart Guide](Quickstart.md) to build your first iOS app with Wat
 
 ## Installation
  
-The Watson iOS SDK requires third-party dependencies such as ObjectMapper and Alamofire.  The dependency management tool Carthage is used to help manage those frameworks.  There are two main methods to install Carthage.  The first method is to download and run the Carthage.pkg installer.  You can locate the latest release [here.](https://github.com/Carthage/Carthage/releases)
+The Watson Developer Cloud iOS SDK requires third-party dependencies such as ObjectMapper and Alamofire.  The dependency management tool Carthage is used to help manage those frameworks.  There are two main methods to install Carthage.  The first method is to download and run the Carthage.pkg installer.  You can locate the latest release [here.](https://github.com/Carthage/Carthage/releases)
 
 The second method of installing is using Homebrew for the download and installation of carthage with the following commands
 


### PR DESCRIPTION
Update name to be "Watson Developer Cloud iOS SDK" instead of "Watson iOS SDK"

We use "Watson Developer cloud XX SDK" since the dependency name is WatsonDeveloperCloud.

* Watson Developer Cloud Node.js SDK
* Watson Developer Cloud Java SDK
* Watson Developer Cloud Python SDK


So this should be:

 * Watson Developer Cloud iOS SDK
