### PR TITLE
[language-translation] Check if model is nil when running the test cases #153

### DIFF
--- a/WatsonDeveloperCloud/LanguageTranslation/Tests/LanguageTranslationTests.swift
+++ b/WatsonDeveloperCloud/LanguageTranslation/Tests/LanguageTranslationTests.swift
@@ -171,8 +171,17 @@ class LanguageTranslationTests: XCTestCase {
         
         service.createModel("en-es", name: "custom-english-to-spanish", fileKey: "forced_glossary", fileURL: fileURL!) { model, error in
             
-            XCTAssertNotNil(model, "Expected non-nil model to be returned.")
             Log.sharedLogger.error("\(error)")
+            
+            // Model creation might not be allowed if using a Bluemix trial account.
+            let isModelAvailable = model != nil
+            guard isModelAvailable else {
+                XCTFail("Expected non-nil model to be returned. Bluemix trial accounts don't have rights to create models.")
+                creationExpectation.fulfill()
+                deletionExpectation.fulfill()
+                return
+            }
+            
             creationExpectation.fulfill()
             
             // Add a small delay so the model is ready for delete.  This is not a normal flow of create and delete immediately


### PR DESCRIPTION
I fixed the issue by checking if model is nil before proceeding with the test. When testing async methods, XCTest enqueue the assertion results, and it fails the test only when *waitForExpectationsWithTimeout(..)* runs. So it is important to not only use *XCTAssertNotNil(...)*, but also stop the async closure if a nil object is found.
I can verify that the same kind of issue is available on other test fixtures. I'll further investigate it and open a new issue for these tests.