### PR TITLE
Remove testable annotation

### DIFF
--- a/WatsonDeveloperCloud/AlchemyLanguage/AlchemyLanguage.swift
+++ b/WatsonDeveloperCloud/AlchemyLanguage/AlchemyLanguage.swift
@@ -93,21 +93,21 @@ public extension AlchemyLanguage {
     
     public struct GetEntitiesParameters: AlchemyLanguageParameters {
         
-        init(){}
+        public init(){}
         
-        var disambiguate: Int? = 1
-        var linkedData: Int? = 1
-        var coreference: Int? = 1
-        var quotations: Int? = 0
-        var sentiment: Int? = 0
-        var sourceText: luri.SourceText? = luri.SourceText.cleaned_or_raw
-        var showSourceText: Int? = 0
-        var cquery: String? = ""
-        var xpath: String? = ""
-        var maxRetrieve: Int? = 50
-        var baseUrl: String? = ""
-        var knowledgGraph: Int? = 0
-        var stucturedEntities: Int? = 1
+        public var disambiguate: Int? = 1
+        public var linkedData: Int? = 1
+        public var coreference: Int? = 1
+        public var quotations: Int? = 0
+        public var sentiment: Int? = 0
+        public var sourceText: luri.SourceText? = luri.SourceText.cleaned_or_raw
+        public var showSourceText: Int? = 0
+        public var cquery: String? = ""
+        public var xpath: String? = ""
+        public var maxRetrieve: Int? = 50
+        public var baseUrl: String? = ""
+        public var knowledgGraph: Int? = 0
+        public var stucturedEntities: Int? = 1
         
     }
     
@@ -173,14 +173,14 @@ public extension AlchemyLanguage {
     
     public struct GetSentimentParameters: AlchemyLanguageParameters {
         
-        init(){}
+        public init(){}
         
-        var sentiment: Int? = 0
-        var showSourceText: Int? = 0
-        var sourceText: luri.SourceText? = luri.SourceText.cleaned_or_raw
-        var cquery: String? = ""
-        var xpath: String? = ""
-        var targets: String? = ""           // required if targeted
+        public var sentiment: Int? = 0
+        public var showSourceText: Int? = 0
+        public var sourceText: luri.SourceText? = luri.SourceText.cleaned_or_raw
+        public var cquery: String? = ""
+        public var xpath: String? = ""
+        public var targets: String? = ""           // required if targeted
         
     }
     
@@ -260,17 +260,17 @@ public extension AlchemyLanguage {
     
     public struct GetKeywordsParameters: AlchemyLanguageParameters {
         
-        init(){}
+        public init(){}
         
-        var sentiment: Int? = 0
-        var sourceText: String? = luri.SourceText.cleaned_or_raw.rawValue
-        var showSourceText: Int? = 0
-        var cquery: String? = ""
-        var xpath: String? = ""
-        var maxRetrieve: Int? = 50
-        var baseUrl: String? = ""
-        var knowledgGraph: Int? = 0
-        var keywordExtractMode: String? = luri.KeywordExtractMode.normal.rawValue
+        public var sentiment: Int? = 0
+        public var sourceText: String? = luri.SourceText.cleaned_or_raw.rawValue
+        public var showSourceText: Int? = 0
+        public var cquery: String? = ""
+        public var xpath: String? = ""
+        public var maxRetrieve: Int? = 50
+        public var baseUrl: String? = ""
+        public var knowledgGraph: Int? = 0
+        public var keywordExtractMode: String? = luri.KeywordExtractMode.normal.rawValue
         
     }
     
@@ -336,16 +336,16 @@ public extension AlchemyLanguage {
     
     public struct GetRankedConceptsParameters: AlchemyLanguageParameters {
         
-        init(){}
+        public init(){}
 
-        var linkedData: Int? = 1
-        var sourceText: String? = luri.SourceText.cleaned_or_raw.rawValue
-        var showSourceText: Int? = 0
-        var cquery: String? = ""
-        var xpath: String? = ""
-        var maxRetrieve: Int? = 50
-        var baseUrl: String? = ""
-        var knowledgGraph: Int? = 0
+        public var linkedData: Int? = 1
+        public var sourceText: String? = luri.SourceText.cleaned_or_raw.rawValue
+        public var showSourceText: Int? = 0
+        public var cquery: String? = ""
+        public var xpath: String? = ""
+        public var maxRetrieve: Int? = 50
+        public var baseUrl: String? = ""
+        public var knowledgGraph: Int? = 0
         
     }
     
@@ -411,22 +411,22 @@ public extension AlchemyLanguage {
     
     public struct GetRelationsParameters: AlchemyLanguageParameters {
         
-        init(){}
+        public init(){}
         
-        var entities: Int? = 0          // extra call
-        var keywords: Int? = 0          // extra call
-        var requireEntities: Int? = 0
-        var sentimentExcludeEntities: Int? = 1
-        var disambiguate: Int? = 1
-        var linkedData: Int? = 1
-        var coreference: Int? = 1
-        var sentiment: Int? = 1         // extra call
-        var sourceText: String? = luri.SourceText.cleaned_or_raw.rawValue
-        var showSourceText: Int? = 0
-        var cquery: String? = ""
-        var xpath: String? = ""
-        var maxRetrieve: Int? = 50
-        var baseUrl: String? = ""
+        public var entities: Int? = 0          // extra call
+        public var keywords: Int? = 0          // extra call
+        public var requireEntities: Int? = 0
+        public var sentimentExcludeEntities: Int? = 1
+        public var disambiguate: Int? = 1
+        public var linkedData: Int? = 1
+        public var coreference: Int? = 1
+        public var sentiment: Int? = 1         // extra call
+        public var sourceText: String? = luri.SourceText.cleaned_or_raw.rawValue
+        public var showSourceText: Int? = 0
+        public var cquery: String? = ""
+        public var xpath: String? = ""
+        public var maxRetrieve: Int? = 50
+        public var baseUrl: String? = ""
         
     }
     
@@ -492,12 +492,12 @@ public extension AlchemyLanguage {
     
     public struct GetRankedTaxonomyParameters: AlchemyLanguageParameters {
         
-        init(){}
+        public init(){}
         
-        var sourceText: String? = luri.SourceText.cleaned_or_raw.rawValue
-        var cquery: String? = ""
-        var xpath: String? = ""
-        var baseUrl: String? = ""
+        public var sourceText: String? = luri.SourceText.cleaned_or_raw.rawValue
+        public var cquery: String? = ""
+        public var xpath: String? = ""
+        public var baseUrl: String? = ""
         
     }
     
@@ -617,11 +617,11 @@ public extension AlchemyLanguage {
     
     public struct GetLanguageParameters: AlchemyLanguageParameters {
         
-        init(){}
+        public init(){}
         
-        var sourceText: String? = luri.SourceText.cleaned_or_raw.rawValue
-        var cquery: String? = ""
-        var xpath: String? = ""
+        public var sourceText: String? = luri.SourceText.cleaned_or_raw.rawValue
+        public var cquery: String? = ""
+        public var xpath: String? = ""
         
     }
     
@@ -687,13 +687,13 @@ public extension AlchemyLanguage {
     
     public struct GetTextParameters: AlchemyLanguageParameters {
         
-        init(){}
+        public init(){}
         
-        var useMetadata: Int? = 1
-        var extractLinks: Int? = 0
-        var sourceText: String? = luri.SourceText.cleaned_or_raw.rawValue
-        var cquery: String? = ""
-        var xpath: String? = ""
+        public var useMetadata: Int? = 1
+        public var extractLinks: Int? = 0
+        public var sourceText: String? = luri.SourceText.cleaned_or_raw.rawValue
+        public var cquery: String? = ""
+        public var xpath: String? = ""
         
     }
     

--- a/WatsonDeveloperCloud/AlchemyLanguage/Tests/AlchemyLanguageTests.swift
+++ b/WatsonDeveloperCloud/AlchemyLanguage/Tests/AlchemyLanguageTests.swift
@@ -15,7 +15,7 @@
  **/
 
 import XCTest
-@testable import WatsonDeveloperCloud
+import WatsonDeveloperCloud
 
 class AlchemyLanguageTests: XCTestCase {
     

--- a/WatsonDeveloperCloud/AlchemyVision/Tests/AlchemyVisionTests.swift
+++ b/WatsonDeveloperCloud/AlchemyVision/Tests/AlchemyVisionTests.swift
@@ -15,8 +15,7 @@
  **/
 
 import XCTest
-
-@testable import WatsonDeveloperCloud
+import WatsonDeveloperCloud
 
 class AlchemyVisionTests: XCTestCase {
     private let timeout: NSTimeInterval = 120.0

--- a/WatsonDeveloperCloud/Dialog/Models/DialogConversation.swift
+++ b/WatsonDeveloperCloud/Dialog/Models/DialogConversation.swift
@@ -23,19 +23,19 @@ extension Dialog {
     public struct Conversation: Mappable {
 
         /// The nodes that were executed by the conversation
-        var hitNodes: [HitNode]?
+        public var hitNodes: [HitNode]?
         
         /// The conversation identifier
-        var conversationID: Int?
+        public var conversationID: Int?
         
         /// The client identifier
-        var clientID: Int?
+        public var clientID: Int?
         
         /// The messages exchanged during the conversation
-        var messages: [Message]?
+        public var messages: [Message]?
         
         /// The profile variables associated with the conversation
-        var profile: [String: String]?
+        public var profile: [String: String]?
 
         /// Used internally to initialize a `Conversation` from JSON.
         public init?(_ map: Map) {}
@@ -54,16 +54,16 @@ extension Dialog {
     public struct HitNode: Mappable {
         
         /// The details of the node
-        var details: String?
+        public var details: String?
         
         /// The label of the node
-        var label: String?
+        public var label: String?
         
         /// The type of the node
-        var type: String?
+        public var type: String?
         
         /// The node identifier
-        var nodeID: Int?
+        public var nodeID: Int?
 
         /// Used internally to initialize a `HitNode` from JSON.
         public init?(_ map: Map) {}
@@ -81,13 +81,13 @@ extension Dialog {
     public struct Message: Mappable {
         
         /// The text of the message
-        var text: String?
+        public var text: String?
         
         /// The date and time of the message
-        var dateTime: NSDate?
+        public var dateTime: NSDate?
         
         /// The client that prompted the message to be sent
-        var fromClient: String?
+        public var fromClient: String?
 
         /// Used internally to initialize a `Message` from JSON.
         public init?(_ map: Map) {}

--- a/WatsonDeveloperCloud/Dialog/Models/DialogNode.swift
+++ b/WatsonDeveloperCloud/Dialog/Models/DialogNode.swift
@@ -28,7 +28,7 @@ extension Dialog {
         /// The type of the node
         public var node: String?
         
-        init(content: String? = nil, node: String? = nil) {
+        public init(content: String? = nil, node: String? = nil) {
             self.content = content
             self.node = node
         }

--- a/WatsonDeveloperCloud/Dialog/Tests/DialogTests.swift
+++ b/WatsonDeveloperCloud/Dialog/Tests/DialogTests.swift
@@ -15,7 +15,7 @@
  **/
 
 import XCTest
-@testable import WatsonDeveloperCloud
+import WatsonDeveloperCloud
 
 class DialogTests: XCTestCase {
     

--- a/WatsonDeveloperCloud/LanguageTranslation/Tests/LanguageTranslationTests.swift
+++ b/WatsonDeveloperCloud/LanguageTranslation/Tests/LanguageTranslationTests.swift
@@ -15,7 +15,7 @@
  **/
 
 import XCTest
-@testable import WatsonDeveloperCloud
+import WatsonDeveloperCloud
 
 class LanguageTranslationTests: XCTestCase {
     /// Language translation service

--- a/WatsonDeveloperCloud/PersonalityInsights/Tests/PersonalityInsightsTests.swift
+++ b/WatsonDeveloperCloud/PersonalityInsights/Tests/PersonalityInsightsTests.swift
@@ -15,7 +15,7 @@
  **/
 
 import XCTest
-@testable import WatsonDeveloperCloud
+import WatsonDeveloperCloud
 
 class PersonalityInsightsTests: XCTestCase {
     

--- a/WatsonDeveloperCloud/SpeechToText/Tests/SpeechToTextTests.swift
+++ b/WatsonDeveloperCloud/SpeechToText/Tests/SpeechToTextTests.swift
@@ -15,7 +15,7 @@
  **/
 
 import XCTest
-@testable import WatsonDeveloperCloud
+import WatsonDeveloperCloud
 
 class SpeechToTextTests: XCTestCase {
 

--- a/WatsonDeveloperCloud/TextToSpeech/Tests/TextToSpeechTests.swift
+++ b/WatsonDeveloperCloud/TextToSpeech/Tests/TextToSpeechTests.swift
@@ -15,8 +15,7 @@
  **/
 
 import XCTest
-
-@testable import WatsonDeveloperCloud
+import WatsonDeveloperCloud
 
 class TextToSpeechTests: XCTestCase {
     

--- a/WatsonDeveloperCloudTests/AuthenticationTests.swift
+++ b/WatsonDeveloperCloudTests/AuthenticationTests.swift
@@ -15,7 +15,7 @@
  **/
 
 import XCTest
-@testable import WatsonDeveloperCloud
+import WatsonDeveloperCloud
 
 class AuthenticationTests: XCTestCase {
     

--- a/WatsonDeveloperCloudTests/WatsonDeveloperCloudTests.swift
+++ b/WatsonDeveloperCloudTests/WatsonDeveloperCloudTests.swift
@@ -15,7 +15,7 @@
  **/
 
 import XCTest
-@testable import WatsonDeveloperCloud
+import WatsonDeveloperCloud
 
 class WatsonDeveloperCloudTests: XCTestCase {
     


### PR DESCRIPTION
### Summary

The `@testable` annotation in Xcode tests allows access to code with the `internal` access modifier. This can hide bugs, since tests pass for models that are `internal` but should be `public`.

By removing the `@testable` annotation, we can be sure that our tests only access the public API of the SDK.