### PR TITLE
Removing warning of ++ operator will be deprecated in Swift 3

### DIFF
--- a/WatsonDeveloperCloud/WatsonCore/WatsonGateway.swift
+++ b/WatsonDeveloperCloud/WatsonCore/WatsonGateway.swift
@@ -88,7 +88,7 @@ internal class WatsonGateway {
         guard authStrategy.token != nil else {
             cachedRequests.append(cachedRequest)
             authStrategy.isRefreshing = true
-            authStrategy.retries++
+            authStrategy.retries += 1
             authStrategy.refreshToken { [weak self] error in
                 authStrategy.isRefreshing = false
                 
@@ -150,7 +150,7 @@ internal class WatsonGateway {
                 }
                 
                 authStrategy.isRefreshing = true
-                authStrategy.retries++
+                authStrategy.retries += 1
                 authStrategy.refreshToken { error in
                     authStrategy.isRefreshing = false
                     guard error == nil else {


### PR DESCRIPTION
<img width="588" alt="screen shot 2016-03-23 at 16 55 38" src="https://cloud.githubusercontent.com/assets/133780/13993391/1e8ce3c6-f118-11e5-9ffe-fcb03604e58c.png">

I see that there is no `develop` branch anymore, so I'm requesting to `master`. Please let me know if it's not the right way.

Thanks