### PR TITLE
Update Starscream

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
 github "Alamofire/Alamofire" "3.3.0"
 github "Hearst-DD/ObjectMapper" "1.2.0"
-github "daltoniam/Starscream" "1.1.2"
+github "daltoniam/Starscream" "1.1.3"
 github "rhodgkins/SwiftHTTPStatusCodes" "2.0.2"
 github "tristanhimmelman/AlamofireObjectMapper" "2.1.3"

--- a/WatsonDeveloperCloud/SpeechToText/SpeechToTextWebSocket.swift
+++ b/WatsonDeveloperCloud/SpeechToText/SpeechToTextWebSocket.swift
@@ -120,7 +120,7 @@ class SpeechToTextWebSocket: WebSocket {
 
      - parameter data: The data to send to the Speech to Text service.
      */
-    override func writeData(data: NSData) {
+    override func writeData(data: NSData, completion: (Void -> Void)? = nil) {
         operations.addOperationWithBlock {
             if self.state == .Listening {
                 self.state = .StartedRequest
@@ -134,7 +134,7 @@ class SpeechToTextWebSocket: WebSocket {
 
      - parameter str: The string to send to the Speech to Text service.
      */
-    override func writeString(str: String) {
+    override func writeString(str: String, completion: (Void -> Void)? = nil) {
         operations.addOperationWithBlock {
             if self.state == .Listening {
                 self.state = .StartedRequest
@@ -148,7 +148,7 @@ class SpeechToTextWebSocket: WebSocket {
 
      - parameter data: Data to include in the ping to the Speech to Text service.
      */
-    override func writePing(data: NSData) {
+    override func writePing(data: NSData, completion: (Void -> Void)? = nil) {
         operations.addOperationWithBlock {
             super.writePing(data)
         }


### PR DESCRIPTION
This PR fixes errors that were introduced with the release of [Starscream v1.1.3](https://github.com/daltoniam/Starscream/releases/tag/1.1.3). In particular, several function signatures were modified, causing the inheritance of `SpeechToTextWebSocket` from `WebSocket` to break. These signatures have been updated so that the SDK successfully builds.

Related Issues: #222