### PR TITLE
Add user agent to WatsonGateway and NetworkUtils

### DIFF
--- a/WatsonDeveloperCloud/WatsonCore/Utilities/NetworkUtils.swift
+++ b/WatsonDeveloperCloud/WatsonCore/Utilities/NetworkUtils.swift
@@ -59,7 +59,7 @@ public class NetworkUtils {
 
             let transform = NSString(string: "Any-Latin; Latin-ASCII; [:^ASCII:] Remove") as CFString
             if CFStringTransform(mutableUserAgent, UnsafeMutablePointer<CFRange>(nil), transform, false) {
-                return userAgent as String
+                return mutableUserAgent as String
             }
         }
 

--- a/WatsonDeveloperCloud/WatsonCore/Utilities/NetworkUtils.swift
+++ b/WatsonDeveloperCloud/WatsonCore/Utilities/NetworkUtils.swift
@@ -46,6 +46,25 @@ public class NetworkUtils {
     private static let _httpContentTypeHeader = "Content-Type"
     private static let _httpAcceptHeader = "Accept"
     private static let _httpAuthorizationHeader = "Authorization"
+    private static let _httpUserAgentHeader = "User-Agent"
+    private static let _userAgent: String = {
+        let wdc = "watson-developer-cloud-ios-0.2.0"
+        if let info = NSBundle.mainBundle().infoDictionary {
+            let executable = info[kCFBundleExecutableKey as String] as? String ?? "Unknown"
+            let bundle = info[kCFBundleIdentifierKey as String] as? String ?? "Unknown"
+            let version = info[kCFBundleVersionKey as String] as? String ?? "Unknown"
+            let os = NSProcessInfo.processInfo().operatingSystemVersionString
+            let userAgent = "\(wdc) \(executable)/\(bundle) (\(version); OS \(os))"
+            let mutableUserAgent = NSMutableString(string: userAgent) as CFMutableString
+
+            let transform = NSString(string: "Any-Latin; Latin-ASCII; [:^ASCII:] Remove") as CFString
+            if CFStringTransform(mutableUserAgent, UnsafeMutablePointer<CFRange>(nil), transform, false) {
+                return userAgent as String
+            }
+        }
+
+        return wdc
+    }()
     
     /**
      This helper function will manipulate the header as needed for a proper payload
@@ -65,6 +84,10 @@ public class NetworkUtils {
         }
         
         guard (header.updateValue(accept.rawValue, forKey: _httpAcceptHeader) == nil) else {
+            return [:]
+        }
+
+        guard (header.updateValue(_userAgent, forKey: _httpUserAgentHeader) == nil) else {
             return [:]
         }
         

--- a/WatsonDeveloperCloud/WatsonCore/WatsonGateway.swift
+++ b/WatsonDeveloperCloud/WatsonCore/WatsonGateway.swift
@@ -51,7 +51,7 @@ internal class WatsonGateway {
 
             let transform = NSString(string: "Any-Latin; Latin-ASCII; [:^ASCII:] Remove") as CFString
             if CFStringTransform(mutableUserAgent, UnsafeMutablePointer<CFRange>(nil), transform, false) {
-                return userAgent as String
+                return mutableUserAgent as String
             }
         }
 

--- a/WatsonDeveloperCloud/WatsonCore/WatsonGateway.swift
+++ b/WatsonDeveloperCloud/WatsonCore/WatsonGateway.swift
@@ -37,9 +37,33 @@ internal class WatsonGateway {
     
     // The maximum number of authentication retries before returning failure.
     private let maxRetries = 1
-    
+
+    // The custom User-Agent header.
+    private static let userAgent: String = {
+        let wdc = "watson-developer-cloud-ios-0.2.0"
+        if let info = NSBundle.mainBundle().infoDictionary {
+            let executable = info[kCFBundleExecutableKey as String] as? String ?? "Unknown"
+            let bundle = info[kCFBundleIdentifierKey as String] as? String ?? "Unknown"
+            let version = info[kCFBundleVersionKey as String] as? String ?? "Unknown"
+            let os = NSProcessInfo.processInfo().operatingSystemVersionString
+            let userAgent = "\(wdc) \(executable)/\(bundle) (\(version); OS \(os))"
+            let mutableUserAgent = NSMutableString(string: userAgent) as CFMutableString
+
+            let transform = NSString(string: "Any-Latin; Latin-ASCII; [:^ASCII:] Remove") as CFString
+            if CFStringTransform(mutableUserAgent, UnsafeMutablePointer<CFRange>(nil), transform, false) {
+                return userAgent as String
+            }
+        }
+
+        return wdc
+    }()
+
     // The shared NSURLSession singleton session.
-    private let session = NSURLSession.sharedSession()
+    private let session: NSURLSession = {
+        let configuration = NSURLSessionConfiguration.defaultSessionConfiguration()
+        configuration.HTTPAdditionalHeaders = ["User-Agent": WatsonGateway.userAgent]
+        return NSURLSession(configuration: configuration)
+    }()
     
     // Private init to override default init and force clients to use the singleton.
     private init() {}


### PR DESCRIPTION
### Summary

This pull request adds a user-agent HTTP header to requests made with `WatsonGateway` and `NetworkUtils`. The user agent begins with the string: "watson-developer-cloud-ios-0.2.0" and also contains information about the executable, bundle, version, and OS.

Note that this pull request does NOT add the user-agent to any multipart form uploads, which are executed directly by Alamofire. It also does NOT add the user-agent to the socket used by Speech to Text.