### PR TITLE
missing profanity filter param added

### DIFF
--- a/WatsonDeveloperCloud/SpeechToText/Models/SpeechToTextSettings.swift
+++ b/WatsonDeveloperCloud/SpeechToText/Models/SpeechToTextSettings.swift
@@ -122,6 +122,7 @@ public struct SpeechToTextSettings: WatsonRequestModel {
         map["keywords_threshold"] = keywordsThreshold
         map["word_alternatives_threshold"] = wordAlternativesThreshold
         map["inactivity_timeout"] = inactivityTimeout
+        map["profanity_filter"] = filterProfanity
         return map
     }
 }


### PR DESCRIPTION
### Summary

profanity filter can be set in settings but it's not sent to the server. so it always takes default value `true`. so there is no way to set profanity filter `false`.