### PR TITLE
[dev-ops] ignore tests in code coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,4 +4,4 @@ coverage:
   status:
     patch: false
   ignore:
-    - Tests/.*
+    - Tests/*

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,7 @@
+comment:
+  layout: header, changes, diff
+coverage:
+  status:
+    patch: false
+  ignore:
+    - Tests/.*


### PR DESCRIPTION
Let's ignore the code coverage information about our testing suite, since we don't want to test our tests.

Related Issues:
- #156