### PR TITLE
Fix Alchemy Vision HTML endpoint

### DIFF
--- a/Source/AlchemyVisionV1/AlchemyVision.swift
+++ b/Source/AlchemyVisionV1/AlchemyVision.swift
@@ -201,7 +201,6 @@ public class AlchemyVision {
 
         // execute REST request
         Alamofire.request(request)
-            .responseString { response in print(response) }
             .responseObject { (response: Response<ImageLink, NSError>) in
                 switch response.result {
                 case.Success(let imageLinks): success(imageLinks)

--- a/Source/AlchemyVisionV1/AlchemyVision.swift
+++ b/Source/AlchemyVisionV1/AlchemyVision.swift
@@ -149,6 +149,30 @@ public class AlchemyVision {
     }
 
     /**
+     Identify the primary image in an HTML file.
+     
+     - parameter html: The HTML file that shall be analyzed to identify the primary image.
+     - parameter url: The HTML file's URL, for response-tracking purposes.
+     - parameter failure: A function executed if an error occurs.
+     - parameter success: A function executed with information about the identified primary image.
+     */
+    public func getImage(
+        html html: NSURL,
+        url: String? = nil,
+        failure: (NSError -> Void)? = nil,
+        success: ImageLink -> Void)
+    {
+        guard let html = try? String(contentsOfURL: html) else {
+            let failureReason = "Failed to read the HTML file."
+            let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
+            let error = NSError(domain: self.domain, code: 0, userInfo: userInfo)
+            failure?(error)
+            return
+        }
+        getImage(html: html, url: url, failure: failure, success: success)
+    }
+    
+    /**
      Identify the primary image in an HTML document.
 
      - parameter html: The HTML document that shall be analyzed to identify the primary image.

--- a/Source/AlchemyVisionV1/Tests/AlchemyVisionTests.swift
+++ b/Source/AlchemyVisionV1/Tests/AlchemyVisionTests.swift
@@ -145,9 +145,12 @@ class AlchemyVisionTests: XCTestCase {
     func testGetImageHTML1() {
         let description = "Identify the primary image in an HTML document."
         let expectation = expectationWithDescription(description)
-        
+        let expectedImageName = "cp_1234354872_16947v1-max-250x250.jpg"
+
         alchemyVision.getImage(html: html, failure: failWithError) { imageLinks in
-            XCTFail("Need to check for `content-is-empty` failure.")
+            XCTAssertEqual(imageLinks.status, "OK")
+            XCTAssertEqual(imageLinks.url, "")
+            XCTAssert(imageLinks.image.containsString(expectedImageName))
             expectation.fulfill()
         }
         waitForExpectations()
@@ -156,9 +159,12 @@ class AlchemyVisionTests: XCTestCase {
     func testGetImageHTML2() {
         let description = "Identify the primary image in an HTML document."
         let expectation = expectationWithDescription(description)
+        let expectedImageName = "cp_1234354872_16947v1-max-250x250.jpg"
         
         alchemyVision.getImage(html: html, url: htmlURL, failure: failWithError) { imageLinks in
-            XCTFail("Need to check for `content-is-empty` failure.")
+            XCTAssertEqual(imageLinks.status, "OK")
+            XCTAssertEqual(imageLinks.url, self.htmlURL)
+            XCTAssert(imageLinks.image.containsString(expectedImageName))
             expectation.fulfill()
         }
         waitForExpectations()

--- a/Source/AlchemyVisionV1/Tests/AlchemyVisionTests.swift
+++ b/Source/AlchemyVisionV1/Tests/AlchemyVisionTests.swift
@@ -25,7 +25,10 @@ class AlchemyVisionTests: XCTestCase {
     private var car: NSURL!
     private var obama: NSURL!
     private var sign: NSURL!
-    private var html: String!
+    private var html: NSURL!
+    
+    private var htmlContents: String!
+    private let htmlImageName = "cp_1234354872_16947v1-max-250x250.jpg"
     
     private let obamaURL = "https://www.whitehouse.gov/sites/whitehouse.gov/files/images/" +
                            "Administration/People/president_official_portrait_lores.jpg"
@@ -76,8 +79,10 @@ class AlchemyVisionTests: XCTestCase {
         self.car = car
         self.obama = obama
         self.sign = sign
-        self.html = try? String(contentsOfURL: html)
-        guard self.html != nil else {
+        self.html = html
+        
+        self.htmlContents = try? String(contentsOfURL: html)
+        guard self.htmlContents != nil else {
             XCTFail("Unable to load html example as String.")
             return
         }
@@ -142,29 +147,53 @@ class AlchemyVisionTests: XCTestCase {
         waitForExpectations()
     }
     
-    func testGetImageHTML1() {
-        let description = "Identify the primary image in an HTML document."
+    func testGetImageHTMLFile1() {
+        let description = "Identify the primary image in an HTML file."
         let expectation = expectationWithDescription(description)
-        let expectedImageName = "cp_1234354872_16947v1-max-250x250.jpg"
-
+        
         alchemyVision.getImage(html: html, failure: failWithError) { imageLinks in
             XCTAssertEqual(imageLinks.status, "OK")
             XCTAssertEqual(imageLinks.url, "")
-            XCTAssert(imageLinks.image.containsString(expectedImageName))
+            XCTAssert(imageLinks.image.containsString(self.htmlImageName))
             expectation.fulfill()
         }
         waitForExpectations()
     }
     
-    func testGetImageHTML2() {
-        let description = "Identify the primary image in an HTML document."
+    func testGetImageHTMLFile2() {
+        let description = "Identify the primary image in an HTML file."
         let expectation = expectationWithDescription(description)
-        let expectedImageName = "cp_1234354872_16947v1-max-250x250.jpg"
         
         alchemyVision.getImage(html: html, url: htmlURL, failure: failWithError) { imageLinks in
             XCTAssertEqual(imageLinks.status, "OK")
             XCTAssertEqual(imageLinks.url, self.htmlURL)
-            XCTAssert(imageLinks.image.containsString(expectedImageName))
+            XCTAssert(imageLinks.image.containsString(self.htmlImageName))
+            expectation.fulfill()
+        }
+        waitForExpectations()
+    }
+    
+    func testGetImageHTMLContents1() {
+        let description = "Identify the primary image in an HTML document."
+        let expectation = expectationWithDescription(description)
+
+        alchemyVision.getImage(html: htmlContents, failure: failWithError) { imageLinks in
+            XCTAssertEqual(imageLinks.status, "OK")
+            XCTAssertEqual(imageLinks.url, "")
+            XCTAssert(imageLinks.image.containsString(self.htmlImageName))
+            expectation.fulfill()
+        }
+        waitForExpectations()
+    }
+    
+    func testGetImageHTMLContents2() {
+        let description = "Identify the primary image in an HTML document."
+        let expectation = expectationWithDescription(description)
+        
+        alchemyVision.getImage(html: htmlContents, url: htmlURL, failure: failWithError) { imageLinks in
+            XCTAssertEqual(imageLinks.status, "OK")
+            XCTAssertEqual(imageLinks.url, self.htmlURL)
+            XCTAssert(imageLinks.image.containsString(self.htmlImageName))
             expectation.fulfill()
         }
         waitForExpectations()


### PR DESCRIPTION
### Summary

This PR fixes an issue with the `HTMLGetImage` endpoint. The previous code incorrectly formatted the request body. This update fixes that by percent encoding the HTML document before constructing the required body.

### Related Issues

#264 