### PR TITLE
Add negative tests for Alchemy Vision

### DIFF
--- a/Source/AlchemyVisionV1/AlchemyVision.swift
+++ b/Source/AlchemyVisionV1/AlchemyVision.swift
@@ -117,7 +117,7 @@ public class AlchemyVision {
         
         // execute REST request
         Alamofire.request(request)
-            .responseObject { (response: Response<FaceTags, NSError>) in
+            .responseObject(dataToError: dataToError) { (response: Response<FaceTags, NSError>) in
                 switch response.result {
                 case .Success(let faceTags): success(faceTags)
                 case .Failure(let error): failure?(error)
@@ -166,7 +166,7 @@ public class AlchemyVision {
 
         // execute REST request
         Alamofire.request(request)
-            .responseObject { (response: Response<FaceTags, NSError>) in
+            .responseObject(dataToError: dataToError) { (response: Response<FaceTags, NSError>) in
                 switch response.result {
                 case .Success(let faceTags): success(faceTags)
                 case .Failure(let error): failure?(error)
@@ -251,7 +251,7 @@ public class AlchemyVision {
 
         // execute REST request
         Alamofire.request(request)
-            .responseObject { (response: Response<ImageLink, NSError>) in
+            .responseObject(dataToError: dataToError) { (response: Response<ImageLink, NSError>) in
                 switch response.result {
                 case.Success(let imageLinks): success(imageLinks)
                 case .Failure(let error): failure?(error)
@@ -288,7 +288,7 @@ public class AlchemyVision {
 
         // execute REST request
         Alamofire.request(request)
-            .responseObject { (response: Response<ImageLink, NSError>) in
+            .responseObject(dataToError: dataToError) { (response: Response<ImageLink, NSError>) in
                 switch response.result {
                 case .Success(let imageLinks): success(imageLinks)
                 case .Failure(let error): failure?(error)
@@ -348,7 +348,7 @@ public class AlchemyVision {
         
         // execute REST request
         Alamofire.request(request)
-            .responseObject { (response: Response<ImageKeywords, NSError>) in
+            .responseObject(dataToError: dataToError) { (response: Response<ImageKeywords, NSError>) in
                 switch response.result {
                 case .Success(let imageKeywords): success(imageKeywords)
                 case .Failure(let error): failure?(error)
@@ -403,7 +403,7 @@ public class AlchemyVision {
 
         // execute REST request
         Alamofire.request(request)
-            .responseObject { (response: Response<ImageKeywords, NSError>) in
+            .responseObject(dataToError: dataToError) { (response: Response<ImageKeywords, NSError>) in
                 switch response.result {
                 case .Success(let imageKeywords): success(imageKeywords)
                 case .Failure(let error): failure?(error)
@@ -445,7 +445,7 @@ public class AlchemyVision {
         
         // execute REST requeset
         Alamofire.request(request)
-            .responseObject { (response: Response<SceneText, NSError>) in
+            .responseObject(dataToError: dataToError) { (response: Response<SceneText, NSError>) in
                 switch response.result {
                 case .Success(let sceneTexts): success(sceneTexts)
                 case .Failure(let error): failure?(error)
@@ -482,7 +482,7 @@ public class AlchemyVision {
 
         // execute REST requeset
         Alamofire.request(request)
-            .responseObject { (response: Response<SceneText, NSError>) in
+            .responseObject(dataToError: dataToError) { (response: Response<SceneText, NSError>) in
                 switch response.result {
                 case .Success(let sceneTexts): success(sceneTexts)
                 case .Failure(let error): failure?(error)

--- a/Source/AlchemyVisionV1/AlchemyVision.swift
+++ b/Source/AlchemyVisionV1/AlchemyVision.swift
@@ -46,6 +46,32 @@ public class AlchemyVision {
         self.apiKey = apiKey
         self.serviceURL = serviceURL
     }
+    
+    /**
+     If the given data represents an error returned by the Alchemy Vision service, then return
+     an NSError with information about the error that occured. Otherwise, return nil.
+     
+     - parameter data: Raw data returned from the service that may represent an error.
+     */
+    
+    private func dataToError(data: NSData) -> NSError? {
+        do {
+            let json = try JSON(data: data)
+            let status = try json.string("status")
+            let statusInfo = try json.string("statusInfo")
+            if status == "OK" {
+                return nil
+            } else {
+                let userInfo = [
+                    NSLocalizedFailureReasonErrorKey: status,
+                    NSLocalizedRecoverySuggestionErrorKey: statusInfo
+                ]
+                return NSError(domain: domain, code: 400, userInfo: userInfo)
+            }
+        } catch {
+            return nil
+        }
+    }
 
     /**
      Perform face recognition on an uploaded image. For each face detected, the service returns

--- a/Source/AlchemyVisionV1/AlchemyVision.swift
+++ b/Source/AlchemyVisionV1/AlchemyVision.swift
@@ -64,7 +64,7 @@ public class AlchemyVision {
             } else {
                 let userInfo = [
                     NSLocalizedFailureReasonErrorKey: status,
-                    NSLocalizedRecoverySuggestionErrorKey: statusInfo
+                    NSLocalizedDescriptionKey: statusInfo
                 ]
                 return NSError(domain: domain, code: 400, userInfo: userInfo)
             }

--- a/Source/AlchemyVisionV1/Tests/AlchemyVisionTests.swift
+++ b/Source/AlchemyVisionV1/Tests/AlchemyVisionTests.swift
@@ -661,4 +661,76 @@ class AlchemyVisionTests: XCTestCase {
         }
         waitForExpectations()
     }
+    
+    // MARK: - Negative Tests
+    
+    func testGetRankedImageFaceTagsWithInvalidURL() {
+        let description = "Perform face recognition at an invalid URL."
+        let expectation = expectationWithDescription(description)
+        
+        let failure = { (error: NSError) in
+            XCTAssertEqual(error.code, 400)
+            expectation.fulfill()
+        }
+        
+        let url = "this-url-is-invalid"
+        alchemyVision.getRankedImageFaceTags(url: url, failure: failure, success: failWithResult)
+        waitForExpectations()
+    }
+    
+    func testGetImageWithInvalidHTML() {
+        let description = "Identify the primary image in an invalid HTML document."
+        let expectation = expectationWithDescription(description)
+        
+        let failure = { (error: NSError) in
+            XCTAssertEqual(error.code, 400)
+            expectation.fulfill()
+        }
+        
+        let html = "this-html-is-invalid"
+        alchemyVision.getImage(html: html, failure: failure, success: failWithResult)
+        waitForExpectations()
+    }
+    
+    func testGetImageWithInvalidURL() {
+        let description = "Identify the primary image at an invalid URL."
+        let expectation = expectationWithDescription(description)
+        
+        let failure = { (error: NSError) in
+            XCTAssertEqual(error.code, 400)
+            expectation.fulfill()
+        }
+        
+        let url = "this-url-is-invalid"
+        alchemyVision.getImage(url: url, failure: failure, success: failWithResult)
+        waitForExpectations()
+    }
+    
+    func testGetRankedImageKeywordsWithInvalidURL() {
+        let description = "Perform image tagging on the primary image at an invalid URL."
+        let expectation = expectationWithDescription(description)
+        
+        let failure = { (error: NSError) in
+            XCTAssertEqual(error.code, 400)
+            expectation.fulfill()
+        }
+        
+        let url = "this-url-is-invalid"
+        alchemyVision.getRankedImageKeywords(url: url, failure: failure, success: failWithResult)
+        waitForExpectations()
+    }
+    
+    func testGetRankedImageSceneTextWithInvalidURL() {
+        let description = "Identify text in the primary image at an invalid URL."
+        let expectation = expectationWithDescription(description)
+        
+        let failure = { (error: NSError) in
+            XCTAssertEqual(error.code, 400)
+            expectation.fulfill()
+        }
+        
+        let url = "this-url-is-invalid"
+        alchemyVision.getRankedImageSceneText(url: url, failure: failure, success: failWithResult)
+        waitForExpectations()
+    }
 }


### PR DESCRIPTION
This pull request adds negative tests for Alchemy Vision. In particular, it:

- includes a `dataToError` function to convert failure responses to an `NSError` that can be propagated to the user,
- ensures that the `dataToError` function is passed with each `responseObject` serialization call, and
- adds negative tests that exercise the `dataToError` function and ways in which the service may fail.

Related Issues: #266