### PR TITLE
Image handling

### DIFF
--- a/Source/AlchemyVisionV1/AlchemyVision.swift
+++ b/Source/AlchemyVisionV1/AlchemyVision.swift
@@ -51,7 +51,7 @@ public class AlchemyVision {
      Perform face recognition on an uploaded image. For each face detected, the service returns
      the estimated bounding box, gender, age, and name (if a celebrity is detected).
  
-     - parameter image: The image file (.jpg, .png, or .gif) on which to perform face recognition.
+     - parameter image: The data representation of the image file on which to perform face recognition.
      - parameter knowledgeGraph: Should additional metadata be provided for detected celebrities?
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with information about the detected faces.
@@ -270,7 +270,7 @@ public class AlchemyVision {
     /**
      Perform image tagging on an uploaded image.
  
-     - parameter image: The image file (.jpg, .png, or .gif) on which to perform face recognition.
+     - parameter image: The data representation of the image file on which to perform face recognition.
      - parameter forceShowAll: Should lower confidence tags be included in the response?
      - parameter knowledgeGraph: Should hierarchical metadata be provided for each tag?
      - parameter failure: A function executed if an error occurs.
@@ -382,7 +382,7 @@ public class AlchemyVision {
     /**
      Identify text in an uploaded image.
  
-     - parameter image: The image file (.jpg, .png, or .gif) on which to perform text detection.
+     - parameter image: The data representation of the image file on which to perform text detection.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the detected text.
      */

--- a/Source/AlchemyVisionV1/AlchemyVision.swift
+++ b/Source/AlchemyVisionV1/AlchemyVision.swift
@@ -57,7 +57,7 @@ public class AlchemyVision {
      - parameter success: A function executed with information about the detected faces.
      */
     public func getRankedImageFaceTags(
-        image image: NSURL,
+        image imageData: NSData,
         knowledgeGraph: Bool? = nil,
         failure: (NSError -> Void)? = nil,
         success: FaceTags -> Void)
@@ -75,9 +75,6 @@ public class AlchemyVision {
             }
         }
         
-        // load image data
-        let data = NSData(contentsOfURL: image)
-        
         // construct REST request
         let request = RestRequest(
             method: .POST,
@@ -86,7 +83,7 @@ public class AlchemyVision {
             contentType: "application/x-www-form-urlencoded",
             userAgent: userAgent,
             queryParameters: queryParameters,
-            messageBody: data
+            messageBody: imageData
         )
         
         // execute REST request
@@ -280,7 +277,7 @@ public class AlchemyVision {
      - parameter success: A function executed with the identified tags.
      */
     public func getRankedImageKeywords(
-        image image: NSURL,
+        image imageData: NSData,
         forceShowAll: Bool? = nil,
         knowledgeGraph: Bool? = nil,
         failure: (NSError -> Void)? = nil,
@@ -306,9 +303,6 @@ public class AlchemyVision {
             }
         }
         
-        // load image data
-        let data = NSData(contentsOfURL: image)
-        
         // construct REST request
         let request = RestRequest(
             method: .POST,
@@ -317,7 +311,7 @@ public class AlchemyVision {
             contentType: "application/x-www-form-urlencoded",
             userAgent: userAgent,
             queryParameters: queryParameters,
-            messageBody: data
+            messageBody: imageData
         )
         
         // execute REST request
@@ -393,7 +387,7 @@ public class AlchemyVision {
      - parameter success: A function executed with the detected text.
      */
     public func getRankedImageSceneText(
-        image image: NSURL,
+        image imageData: NSData,
         failure: (NSError -> Void)? = nil,
         success: SceneText -> Void)
     {
@@ -402,10 +396,7 @@ public class AlchemyVision {
         queryParameters.append(NSURLQueryItem(name: "apikey", value: apiKey))
         queryParameters.append(NSURLQueryItem(name: "outputMode", value: "json"))
         queryParameters.append(NSURLQueryItem(name: "imagePostMode", value: "raw"))
-        
-        // load image data
-        let data = NSData(contentsOfURL: image)
-        
+
         // construct REST request
         let request = RestRequest(
             method: .POST,
@@ -414,7 +405,7 @@ public class AlchemyVision {
             contentType: "application/x-www-form-urlencoded",
             userAgent: userAgent,
             queryParameters: queryParameters,
-            messageBody: data
+            messageBody: imageData
         )
         
         // execute REST requeset

--- a/Source/AlchemyVisionV1/Tests/AlchemyVisionTests.swift
+++ b/Source/AlchemyVisionV1/Tests/AlchemyVisionTests.swift
@@ -22,9 +22,9 @@ class AlchemyVisionTests: XCTestCase {
     private var alchemyVision: AlchemyVision!
     private let timeout: NSTimeInterval = 30.0
 
-    private var car: NSURL!
-    private var obama: NSURL!
-    private var sign: NSURL!
+    private var car: NSData!
+    private var obama: NSData!
+    private var sign: NSData!
     private var html: NSURL!
     
     private var htmlContents: String!
@@ -67,9 +67,9 @@ class AlchemyVisionTests: XCTestCase {
     func loadResources() {
         let bundle = NSBundle(forClass: self.dynamicType)
         guard
-            let car = bundle.URLForResource("car", withExtension: "png"),
-            let obama = bundle.URLForResource("obama", withExtension: "jpg"),
-            let sign = bundle.URLForResource("sign", withExtension: "jpg"),
+            let car = NSData(contentsOfURL: bundle.URLForResource("car", withExtension: "png")!),
+            let obama = NSData(contentsOfURL: bundle.URLForResource("obama", withExtension: "jpg")!),
+            let sign = NSData(contentsOfURL: bundle.URLForResource("sign", withExtension: "jpg")!),
             let html = bundle.URLForResource("example", withExtension: "html")
         else {
             XCTFail("Unable to locate testing resources.")
@@ -110,7 +110,7 @@ class AlchemyVisionTests: XCTestCase {
     func testGetRankedImageFaceTagsImage1() {
         let description = "Perform face recognition on an uploaded image."
         let expectation = expectationWithDescription(description)
-        
+
         alchemyVision.getRankedImageFaceTags(image: obama, failure: failWithError) { faceTags in
             
             // verify faceTags structure
@@ -169,7 +169,7 @@ class AlchemyVisionTests: XCTestCase {
     func testGetRankedImageFaceTagsImage2() {
         let description = "Perform face recognition on an uploaded image."
         let expectation = expectationWithDescription(description)
-        
+
         alchemyVision.getRankedImageFaceTags(image: obama, knowledgeGraph: true, failure: failWithError) { faceTags in
             
             // verify faceTags structure
@@ -411,7 +411,7 @@ class AlchemyVisionTests: XCTestCase {
     func testGetRankedImageKeywordsImage1() {
         let description = "Perform image tagging on an uploaded image."
         let expectation = expectationWithDescription(description)
-        
+
         alchemyVision.getRankedImageKeywords(image: car, failure: failWithError) { imageKeywords in
             
             // verify imageKeywords structure
@@ -452,7 +452,7 @@ class AlchemyVisionTests: XCTestCase {
     func testGetRankedImageKeywordsImage2() {
         let description = "Perform image tagging on an uploaded image."
         let expectation = expectationWithDescription(description)
-        
+
         alchemyVision.getRankedImageKeywords(image: car, forceShowAll: true, knowledgeGraph: true, failure: failWithError) { imageKeywords in
             
             // verify imageKeywords structure
@@ -575,7 +575,7 @@ class AlchemyVisionTests: XCTestCase {
     func testGetRankedImageSceneTextImage() {
         let description = "Identify text in an uploaded image."
         let expectation = expectationWithDescription(description)
-        
+
         alchemyVision.getRankedImageSceneText(image: sign, failure: failWithError) { sceneTexts in
             
             // verify sceneTexts structure


### PR DESCRIPTION
### Summary

Using NSURL invokes some trouble with Image Handling. If you choose a Photo from your Camera Roll you get an UIImage or a referencing URL to the Asset. The Initializer NSData(contentsOfURL: ...), which is used in the [API](https://github.com/watson-developer-cloud/ios-sdk/blob/master/Source/AlchemyVisionV1/AlchemyVision.swift#L105), does not handle Asset URLs correctly. 
It seems to me, that NSData reduces a lot of pains for the developers. They can choose what they want to use: Loading from Assets and convert to NSData or transforming UIImage to an UIImagePNGRepresentation and so on.

An other way would be, to use UIImage instead of NSData and make the conversation in the AlchemyVision API.

### Other Information

I am looking forward to your Feedback.