### PR TITLE
Add TextToSpeech test for empty string

### DIFF
--- a/Source/TextToSpeechV1/Tests/TextToSpeechTests.swift
+++ b/Source/TextToSpeechV1/Tests/TextToSpeechTests.swift
@@ -695,7 +695,6 @@ class TextToSpeechTests: XCTestCase {
         let expectation = expectationWithDescription(description)
         
         let failure = { (error: NSError) in
-            print(error)
             XCTAssertEqual(error.code, 400)
             expectation.fulfill()
         }

--- a/Source/TextToSpeechV1/Tests/TextToSpeechTests.swift
+++ b/Source/TextToSpeechV1/Tests/TextToSpeechTests.swift
@@ -689,6 +689,21 @@ class TextToSpeechTests: XCTestCase {
         waitForExpectations()
     }
     
+    /** Synthesize an empty string. */
+    func testSynthesizeEmptyString() {
+        let description = "Synthesize an empty string."
+        let expectation = expectationWithDescription(description)
+        
+        let failure = { (error: NSError) in
+            print(error)
+            XCTAssertEqual(error.code, 400)
+            expectation.fulfill()
+        }
+        
+        textToSpeech.synthesize("", failure: failure, success: failWithResult)
+        waitForExpectations()
+    }
+    
     /** Synthesize text to spoken audio using an invalid voice. */
     func testSynthesizeWithInvalidVoice() {
         let description = "Synthesize text to spoken audio using an invalid voice."


### PR DESCRIPTION
This PR adds a negative test to synthesize an empty string with the Text to Speech service. This helps document the expected behavior for this scenario (i.e. a 400 error).