### PR TITLE
Add deprecation annotation to RelationshipExtraction

### DIFF
--- a/Source/RelationshipExtractionV1Beta/RelationshipExtraction.swift
+++ b/Source/RelationshipExtractionV1Beta/RelationshipExtraction.swift
@@ -27,6 +27,7 @@ import RestKit
  text that refers to entities, cluster them together to form entities, and extract the relationships 
  between the entities.
  */
+@available(*, deprecated, message="Relationship Extraction will be deprecated on July 27th 2016. If you want to continue using Relationship Extraction models, you can now access them with AlchemyLanguage. See the migration guide for details.")
 public class RelationshipExtraction {
     private let username: String
     private let password: String


### PR DESCRIPTION
This pull request adds a deprecation annotation to Relationship Extraction to alert users to use the AlchemyLanguage service instead.