### PR TITLE
Change forUrl to forURL

### DIFF
--- a/Source/AlchemyLanguageV1/AlchemyLanguage.swift
+++ b/Source/AlchemyLanguageV1/AlchemyLanguage.swift
@@ -89,7 +89,7 @@ public class AlchemyLanguage {
      - parameter success: a function executed with Author information
      */
     public func getAuthors(
-        forUrl url: String,
+        forURL url: String,
         failure: (NSError -> Void)? = nil,
         success: DocumentAuthors -> Void)
     {
@@ -176,7 +176,7 @@ public class AlchemyLanguage {
      - parameter success:        a function executed with Concept information
      */
     public func getRankedConcepts(
-        forUrl url: String,
+        forURL url: String,
         knowledgeGraph: QueryParam? = nil,
         failure: (NSError -> Void)? = nil,
         success: ConceptResponse -> Void)
@@ -334,7 +334,7 @@ public class AlchemyLanguage {
      - parameter success:              a function executed with Entity information
      */
     public func getRankedNamedEntities(
-        forUrl url: String,
+        forURL url: String,
         knowledgeGraph: QueryParam? = nil,
         disambiguateEntities: QueryParam? = nil,
         linkedData: QueryParam? = nil,
@@ -575,7 +575,7 @@ public class AlchemyLanguage {
      - parameter success:        a function executed with Keyword information
      */
     public func getRankedKeywords(
-        forUrl url: String,
+        forURL url: String,
         knowledgeGraph: QueryParam? = nil,
         sentiment: QueryParam? = nil,
         strictMode: Bool? = false,
@@ -763,7 +763,7 @@ public class AlchemyLanguage {
      - parameter success: a function executed with Language information
      */
     public func getLanguage(
-        forUrl url: String,
+        forURL url: String,
         failure: (NSError -> Void)? = nil,
         success: Language -> Void)
     {
@@ -842,7 +842,7 @@ public class AlchemyLanguage {
      - parameter success: a function executed with Microformat information
      */
     public func getMicroformatData(
-        forUrl url: String,
+        forURL url: String,
         failure: (NSError -> Void)? = nil,
         success: Microformats -> Void)
     {
@@ -927,7 +927,7 @@ public class AlchemyLanguage {
      - parameter success: a function executed with Publication information
      */
     public func getPubDate(
-        forUrl url: String,
+        forURL url: String,
         failure: (NSError -> Void)? = nil,
         success: PublicationResponse -> Void)
     {
@@ -1020,7 +1020,7 @@ public class AlchemyLanguage {
      - parameter success:                  a function executed with Relationship information
      */
     public func getRelations(
-        forUrl url: String,
+        forURL url: String,
         knowledgeGraph: QueryParam? = nil,
         disambiguateEntities: QueryParam? = nil,
         linkedData: QueryParam? = nil,
@@ -1280,7 +1280,7 @@ public class AlchemyLanguage {
      - parameter success: a function executed with Sentiment information
      */
     public func getTextSentiment(
-        forUrl url: String,
+        forURL url: String,
         failure: (NSError -> Void)? = nil,
         success: SentimentResponse -> Void)
     {
@@ -1407,7 +1407,7 @@ public class AlchemyLanguage {
      - parameter success: a function executed with Sentiment information
      */
     public func getTargetedSentiment(
-        forUrl url: String,
+        forURL url: String,
         target: String,
         failure: (NSError -> Void)? = nil,
         success: SentimentResponse -> Void)
@@ -1540,7 +1540,7 @@ public class AlchemyLanguage {
      - parameter success: a function executed with Taxonomy information
      */
     public func getRankedTaxonomy(
-        forUrl url: String,
+        forURL url: String,
         failure: (NSError -> Void)? = nil,
         success: Taxonomies -> Void)
     {
@@ -1665,7 +1665,7 @@ public class AlchemyLanguage {
      - parameter success: a function executed with Raw Text information
      */
     public func getRawText(
-        forUrl url: String,
+        forURL url: String,
         failure: (NSError -> Void)? = nil,
         success: DocumentText -> Void)
     {
@@ -1750,7 +1750,7 @@ public class AlchemyLanguage {
      - parameter success:      a function executed with Text information
      */
     public func getText(
-        forUrl url: String,
+        forURL url: String,
         useMetadata: QueryParam? = nil,
         extractLinks: QueryParam? = nil,
         failure: (NSError -> Void)? = nil,
@@ -1854,7 +1854,7 @@ public class AlchemyLanguage {
      - parameter success:      a function executed with Title information
      */
     public func getTitle(
-        forUrl url: String,
+        forURL url: String,
         useMetadata: QueryParam? = nil,
         failure: (NSError -> Void)? = nil,
         success: DocumentTitle -> Void)
@@ -1948,7 +1948,7 @@ public class AlchemyLanguage {
      - parameter success:      a function executed with Feed information
      */
     public func getFeedLinks(
-        forUrl url: String,
+        forURL url: String,
         failure: (NSError -> Void)? = nil,
         success: Feeds -> Void)
     {
@@ -2032,7 +2032,7 @@ public class AlchemyLanguage {
      - parameter success:      a function executed with Feed information
      */
     public func getEmotion(
-        forUrl url: String,
+        forURL url: String,
         failure: (NSError -> Void)? = nil,
         success: DocumentEmotion -> Void)
     {

--- a/Source/AlchemyLanguageV1/Tests/AlchemyLanguageTests.swift
+++ b/Source/AlchemyLanguageV1/Tests/AlchemyLanguageTests.swift
@@ -73,7 +73,7 @@ class AlchemyLanguageTests: XCTestCase {
         let description = "Get the author of an Ars article"
         let expectation = expectationWithDescription(description)
 
-        service.getAuthors(forUrl: testUrl, failure: failWithError) { authors in
+        service.getAuthors(forURL: testUrl, failure: failWithError) { authors in
             XCTAssertNotNil(authors, "Response should not be nil")
             XCTAssertNotNil(authors.authors, "Authors should not be nil")
             expectation.fulfill()
@@ -101,7 +101,7 @@ class AlchemyLanguageTests: XCTestCase {
         let description = "Get the ranked concepts of an Ars article"
         let expectation = expectationWithDescription(description)
         
-        service.getRankedConcepts(forUrl: testUrl, failure: failWithError) { concepts in
+        service.getRankedConcepts(forURL: testUrl, failure: failWithError) { concepts in
             XCTAssertNotNil(concepts, "Reponse should not be nil")
             XCTAssertNotNil(concepts.concepts, "Concepts should not be nil")
             expectation.fulfill()
@@ -173,7 +173,7 @@ class AlchemyLanguageTests: XCTestCase {
         let description = "Get the entities of an Ars article"
         let expectation = expectationWithDescription(description)
         
-        service.getRankedNamedEntities(forUrl: testUrl, failure: failWithError) { entities in
+        service.getRankedNamedEntities(forURL: testUrl, failure: failWithError) { entities in
             XCTAssertNotNil(entities, "Response should not be nil")
             XCTAssertNotNil(entities.entitites, "Entities should not be nil")
             expectation.fulfill()
@@ -214,7 +214,7 @@ class AlchemyLanguageTests: XCTestCase {
     func testGetRankedKeywordsURL() {
         let description = "Get the keywords of an Ars article"
         let expectation = expectationWithDescription(description)
-        service.getRankedKeywords(forUrl: testUrl, failure: failWithError) { keywords in
+        service.getRankedKeywords(forURL: testUrl, failure: failWithError) { keywords in
             XCTAssertNotNil(keywords, "Response should not be nil")
             XCTAssertNotNil(keywords.keywords, "Keywords should not be nil")
             expectation.fulfill()
@@ -253,7 +253,7 @@ class AlchemyLanguageTests: XCTestCase {
     func testGetLanguageURL() {
         let description = "Get the language of an Ars article"
         let expectation = expectationWithDescription(description)
-        service.getLanguage(forUrl: testUrl, failure: failWithError) { language in
+        service.getLanguage(forURL: testUrl, failure: failWithError) { language in
             XCTAssertNotNil(language, "Response should not be nil")
             XCTAssertNotNil(language.language, "Language should not be nil")
             expectation.fulfill()
@@ -278,7 +278,7 @@ class AlchemyLanguageTests: XCTestCase {
     func testGetMicroformatsURL() {
         let description = "Get the microformats of an Ars article"
         let expectation = expectationWithDescription(description)
-        service.getMicroformatData(forUrl: testUrl, failure: failWithError) { microformats in
+        service.getMicroformatData(forURL: testUrl, failure: failWithError) { microformats in
             XCTAssertNotNil(microformats, "Response should not be nil")
             XCTAssertNotNil(microformats.microformats, "Microformats should not be nil")
             expectation.fulfill()
@@ -303,7 +303,7 @@ class AlchemyLanguageTests: XCTestCase {
     func testGetPubDateURL() {
         let description = "Get the publication date of an Ars article"
         let expectation = expectationWithDescription(description)
-        service.getPubDate(forUrl: testUrl, failure: failWithError) { pubDate in
+        service.getPubDate(forURL: testUrl, failure: failWithError) { pubDate in
             XCTAssertNotNil(pubDate, "Response should not be nil")
             XCTAssertNotNil(pubDate.publicationDate, "Publication date should not be nil")
             expectation.fulfill()
@@ -328,7 +328,7 @@ class AlchemyLanguageTests: XCTestCase {
     func testGetRelationsURL() {
         let description = "Get the Subject-Action-Object relations of an Ars article"
         let expectation = expectationWithDescription(description)
-        service.getRelations(forUrl: testUrl, failure: failWithError) { relations in
+        service.getRelations(forURL: testUrl, failure: failWithError) { relations in
             XCTAssertNotNil(relations, "Response should not be nil")
             XCTAssertNotNil(relations.relations, "Relations should not be nil")
             expectation.fulfill()
@@ -367,7 +367,7 @@ class AlchemyLanguageTests: XCTestCase {
     func testGetTextSentimentURL() {
         let description = "Get the sentiment of an Ars article"
         let expectation = expectationWithDescription(description)
-        service.getTextSentiment(forUrl: testUrl, failure: failWithError) { sentiment in
+        service.getTextSentiment(forURL: testUrl, failure: failWithError) { sentiment in
             XCTAssertNotNil(sentiment, "Response should not be nil")
             XCTAssertNotNil(sentiment.docSentiment, "Sentiment should not be nil")
             expectation.fulfill()
@@ -409,7 +409,7 @@ class AlchemyLanguageTests: XCTestCase {
         let description = "Get the sentiment of a phrase in an Ars article"
         let expectation = expectationWithDescription(description)
         let phrase = "Developers who want to offer Instant Apps will have to modularize their apps"
-        service.getTargetedSentiment(forUrl: testUrl, target: phrase, failure: failWithError) { sentiment in
+        service.getTargetedSentiment(forURL: testUrl, target: phrase, failure: failWithError) { sentiment in
             XCTAssertNotNil(sentiment, "Response should not be nil")
             XCTAssertNotNil(sentiment.docSentiment, "Sentiment should not be nil")
             expectation.fulfill()
@@ -452,7 +452,7 @@ class AlchemyLanguageTests: XCTestCase {
     func testGetRankedTaxonomyURL() {
         let description = "Get the taxonomies of an Ars article"
         let expectation = expectationWithDescription(description)
-        service.getRankedTaxonomy(forUrl: testUrl, failure: failWithError) { taxonomies in
+        service.getRankedTaxonomy(forURL: testUrl, failure: failWithError) { taxonomies in
             XCTAssertNotNil(taxonomies, "Response should not be nil")
             XCTAssertNotNil(taxonomies.taxonomy, "Taxonomies should not be nil")
             expectation.fulfill()
@@ -493,7 +493,7 @@ class AlchemyLanguageTests: XCTestCase {
     func testGetRawTextURL() {
         let description = "Get the raw text of an Ars article"
         let expectation = expectationWithDescription(description)
-        service.getRawText(forUrl: testUrl, failure: failWithError) { rawText in
+        service.getRawText(forURL: testUrl, failure: failWithError) { rawText in
             XCTAssertNotNil(rawText, "Response should not be nil")
             XCTAssertNotNil(rawText.text, "Response should not be nil")
             expectation.fulfill()
@@ -519,7 +519,7 @@ class AlchemyLanguageTests: XCTestCase {
     func testGetTextURL() {
         let description = "Get the text of an Ars article"
         let expectation = expectationWithDescription(description)
-        service.getText(forUrl: testUrl, failure: failWithError) { text in
+        service.getText(forURL: testUrl, failure: failWithError) { text in
             XCTAssertNotNil(text, "Response should not be nil")
             XCTAssertNotNil(text.text, "Text should not be nil")
             expectation.fulfill()
@@ -545,7 +545,7 @@ class AlchemyLanguageTests: XCTestCase {
     func testGetTitleURL() {
         let description = "Get the title of an Ars article"
         let expectation = expectationWithDescription(description)
-        service.getTitle(forUrl: testUrl, failure: failWithError) { title in
+        service.getTitle(forURL: testUrl, failure: failWithError) { title in
             XCTAssertNotNil(title, "Response should not be nil")
             XCTAssertNotNil(title.title, "Title should not be nil")
             expectation.fulfill()
@@ -572,7 +572,7 @@ class AlchemyLanguageTests: XCTestCase {
         let description = "Get the feeds of an Ars article"
         let expectation = expectationWithDescription(description)
         
-        service.getFeedLinks(forUrl: testUrl, failure: failWithError) { feeds in
+        service.getFeedLinks(forURL: testUrl, failure: failWithError) { feeds in
             XCTAssertNotNil(feeds, "Response should not be nil")
             XCTAssertNotNil(feeds.feeds, "Feeds should not be nil")
             expectation.fulfill()
@@ -598,7 +598,7 @@ class AlchemyLanguageTests: XCTestCase {
         let description = "Get the emotion of an Ars article"
         let expectation = expectationWithDescription(description)
     
-        service.getEmotion(forUrl: testUrl, failure: failWithError) { emotion in
+        service.getEmotion(forURL: testUrl, failure: failWithError) { emotion in
             XCTAssertNotNil(emotion, "Response should not be nil")
             XCTAssertNotNil(emotion.docEmotions, "Feeds should not be nil")
             expectation.fulfill()
@@ -645,7 +645,7 @@ class AlchemyLanguageTests: XCTestCase {
             expectation.fulfill()
         }
         
-        service.getFeedLinks(forUrl: "DOGS", failure: failure, success: failWithResult)
+        service.getFeedLinks(forURL: "DOGS", failure: failure, success: failWithResult)
         waitForExpectations()
     }
     


### PR DESCRIPTION
According to the Swift 3 API Design Guidelines: "Acronyms and initialisms that commonly appear as all upper case in American English should be uniformly up- or down-cased according to case conventions."

This change updates the AlchemyLanguage API for better consistency with the Swift 3 API Design Guidelines.