### PR TITLE
Update contributing documentation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -12,14 +12,14 @@ See the [issue template](issue_template.md).
 
 If you want to contribute to the repository, here's a quick guide:
   1. Fork the repository.
-  2. Develop and test your code changes. Be sure to build the project and run tests in the test navigator.
-    * Respect the original code [style guide][styleguide].
+  2. Copy `CredentialsExample.plist` to `Credentials.plist`.
+  3. Add credentials to `Credentials.plist` for the services you plan to test.
+  4. Develop and test your code changes.
+    * Please respect the original code [style guide][styleguide].
     * Create minimal diffs - disable on save actions like reformat source code or organize imports. If you feel the source code should be reformatted create a separate PR for this change.
     * Check for unnecessary whitespace with `git diff --check` before committing.
-  3. Ensure all tests pass successfully.
-  4. Commit your changes.
-  5. Push to your fork and submit a pull request to the **master** branch.
-  6. See our [pull request template](pull_request_template.md)
+  5. Verify that tests pass successfully.
+  6. Push to your fork and submit a pull request to the **master** branch.
 
 # Developer's Certificate of Origin 1.1
 


### PR DESCRIPTION
This pull request updates the [CONTRIBUTING.md](https://github.com/watson-developer-cloud/ios-sdk/blob/master/.github/CONTRIBUTING.md) file to include more information about configuring the `Credentials.plist` file.