### PR TITLE
Fix Conversation bug with dialog stack

### DIFF
--- a/Source/ConversationV1/Models/Context.swift
+++ b/Source/ConversationV1/Models/Context.swift
@@ -94,7 +94,7 @@ public struct SystemResponse: JSONEncodable, JSONDecodable {
     /// Used internally to serialize a `SystemResponse` model to JSON.
     public func toJSON() -> JSON {
         var json = [String: JSON]()
-        json["dialogStack"] = .Array(dialogStack.map { .String($0) })
+        json["dialog_stack"] = .Array(dialogStack.map { .String($0) })
         json["dialog_turn_counter"] = .Int(dialogTurnCounter)
         json["dialog_request_counter"] = .Int(dialogRequestCounter)
         return JSON.Dictionary(json)


### PR DESCRIPTION
This pull request changes the `dialogStack` key to `dialog_stack`, as expected by the Conversation service. It fixes a bug where conversation context was not being sufficiently maintained.