### PR TITLE
Update Error Handling

### DIFF
--- a/Source/AlchemyDataNewsV1/AlchemyDataNews.swift
+++ b/Source/AlchemyDataNewsV1/AlchemyDataNews.swift
@@ -41,21 +41,6 @@ public class AlchemyDataNews {
         self.apiKey = apiKey
     }
     
-    private func dataToError(data: NSData) -> NSError? {
-        do {
-            let json = try JSON(data: data)
-            let status = try json.string("status")
-            let statusInfo = try json.string("statusInfo")
-            let userInfo = [
-                NSLocalizedFailureReasonErrorKey: status,
-                NSLocalizedDescriptionKey: statusInfo
-            ]
-            return NSError(domain: errorDomain, code: 400, userInfo: userInfo)
-        } catch {
-            return nil
-        }
-    }
-    
     /**
      Returns articles matching the query. If no query is given, simply returns a count of articles
      matching the start/end timeframe.
@@ -106,7 +91,7 @@ public class AlchemyDataNews {
         
         // execute request
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<NewsResponse, NSError>) in
                 switch response.result {
                 case .Success(let newsResponse): success(newsResponse)

--- a/Source/AlchemyLanguageV1/AlchemyLanguage.swift
+++ b/Source/AlchemyLanguageV1/AlchemyLanguage.swift
@@ -46,21 +46,6 @@ public class AlchemyLanguage {
         self.apiKey = apiKey
     }
     
-    private func dataToError(data: NSData) -> NSError? {
-        do {
-            let json = try JSON(data: data)
-            let status = try json.string("status")
-            let statusInfo = try json.string("statusInfo")
-            let userInfo = [
-                NSLocalizedFailureReasonErrorKey: status,
-                NSLocalizedDescriptionKey: statusInfo
-            ]
-            return NSError(domain: errorDomain, code: 400, userInfo: userInfo)
-        } catch {
-            return nil
-        }
-    }
-    
     private func buildBody(document: NSURL, html: Bool) throws -> NSData {
         guard let docAsString = try? String(contentsOfURL: document)
             .stringByAddingPercentEncodingWithAllowedCharacters(unreservedCharacters) else {
@@ -113,7 +98,7 @@ public class AlchemyLanguage {
         
         // execute request
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<DocumentAuthors, NSError>) in
                 switch response.result {
                 case .Success(let authors): success(authors)
@@ -161,7 +146,7 @@ public class AlchemyLanguage {
         
         // execute request
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<DocumentAuthors, NSError>) in
                 switch response.result {
                 case .Success(let authors): success(authors)
@@ -209,7 +194,7 @@ public class AlchemyLanguage {
         
         // execute request
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<ConceptResponse, NSError>) in
                 switch response.result {
                 case .Success(let concepts): success(concepts)
@@ -263,7 +248,7 @@ public class AlchemyLanguage {
         
         // execute request
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<ConceptResponse, NSError>) in
                 switch response.result {
                 case .Success(let concepts): success(concepts)
@@ -313,7 +298,7 @@ public class AlchemyLanguage {
         
         // execute request
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<ConceptResponse, NSError>) in
                 switch response.result {
                 case .Success(let concepts): success(concepts)
@@ -391,7 +376,7 @@ public class AlchemyLanguage {
         
         // execute request
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<Entities, NSError>) in
                 switch response.result {
                 case .Success(let entities): success(entities)
@@ -477,7 +462,7 @@ public class AlchemyLanguage {
         
         // execute request
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<Entities, NSError>) in
                 switch response.result {
                 case .Success(let entities): success(entities)
@@ -558,7 +543,7 @@ public class AlchemyLanguage {
         
         // execute request
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<Entities, NSError>) in
                 switch response.result {
                 case .Success(let entities): success(entities)
@@ -618,7 +603,7 @@ public class AlchemyLanguage {
         
         // execute request
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<Keywords, NSError>) in
                 switch response.result {
                 case .Success(let keywords): success(keywords)
@@ -686,7 +671,7 @@ public class AlchemyLanguage {
         
         // execute request
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<Keywords, NSError>) in
                 switch response.result {
                 case .Success(let keywords): success(keywords)
@@ -749,7 +734,7 @@ public class AlchemyLanguage {
         
         // execute request
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<Keywords, NSError>) in
                 switch response.result {
                 case .Success(let keywords): success(keywords)
@@ -786,7 +771,7 @@ public class AlchemyLanguage {
         
         // execute request
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<Language, NSError>) in
                 switch response.result {
                 case .Success(let language): success(language)
@@ -828,7 +813,7 @@ public class AlchemyLanguage {
         
         // execute request
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<Language, NSError>) in
                 switch response.result {
                 case .Success(let language): success(language)
@@ -865,7 +850,7 @@ public class AlchemyLanguage {
         
         // execute request
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<Microformats, NSError>) in
                 switch response.result {
                 case .Success(let microformats): success(microformats)
@@ -913,7 +898,7 @@ public class AlchemyLanguage {
         
         // execute request
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<Microformats, NSError>) in
                 switch response.result {
                 case .Success(let microformats): success(microformats)
@@ -950,7 +935,7 @@ public class AlchemyLanguage {
         
         // execute request
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<PublicationResponse, NSError>) in
                 switch response.result {
                 case .Success(let pubResponse): success(pubResponse)
@@ -997,7 +982,7 @@ public class AlchemyLanguage {
         
         // execute request
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<PublicationResponse, NSError>) in
                 switch response.result {
                 case .Success(let pubResponse): success(pubResponse)
@@ -1083,7 +1068,7 @@ public class AlchemyLanguage {
         
         // execute request
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<SAORelations, NSError>) in
                 switch response.result {
                 case .Success(let relations): success(relations)
@@ -1177,7 +1162,7 @@ public class AlchemyLanguage {
         
         // execute request
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<SAORelations, NSError>) in
                 switch response.result {
                 case .Success(let relations): success(relations)
@@ -1266,7 +1251,7 @@ public class AlchemyLanguage {
         
         // execute request
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<SAORelations, NSError>) in
                 switch response.result {
                 case .Success(let relations): success(relations)
@@ -1303,7 +1288,7 @@ public class AlchemyLanguage {
         
         // execute request
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<SentimentResponse, NSError>) in
                 switch response.result {
                 case .Success(let sentimentResponse): success(sentimentResponse)
@@ -1350,7 +1335,7 @@ public class AlchemyLanguage {
         
         // execute request
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<SentimentResponse, NSError>) in
                 switch response.result {
                 case .Success(let sentimentResponse): success(sentimentResponse)
@@ -1392,7 +1377,7 @@ public class AlchemyLanguage {
         
         // execute request
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<SentimentResponse, NSError>) in
                 switch response.result {
                 case .Success(let sentimentResponse): success(sentimentResponse)
@@ -1431,7 +1416,7 @@ public class AlchemyLanguage {
         
         // execute request
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<SentimentResponse, NSError>) in
                 switch response.result {
                 case .Success(let sentimentResponse): success(sentimentResponse)
@@ -1481,7 +1466,7 @@ public class AlchemyLanguage {
         
         // execute request
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<SentimentResponse, NSError>) in
                 switch response.result {
                 case .Success(let sentimentResponse): success(sentimentResponse)
@@ -1526,7 +1511,7 @@ public class AlchemyLanguage {
         
         // execute request
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<SentimentResponse, NSError>) in
                 switch response.result {
                 case .Success(let sentimentResponse): success(sentimentResponse)
@@ -1562,7 +1547,7 @@ public class AlchemyLanguage {
         
         // execute request
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<Taxonomies, NSError>) in
                 switch response.result {
                 case .Success(let taxonomies): success(taxonomies)
@@ -1609,7 +1594,7 @@ public class AlchemyLanguage {
         
         // execute request
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<Taxonomies, NSError>) in
                 switch response.result {
                 case .Success(let taxonomies): success(taxonomies)
@@ -1651,7 +1636,7 @@ public class AlchemyLanguage {
         
         // execute request
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<Taxonomies, NSError>) in
                 switch response.result {
                 case .Success(let taxonomies): success(taxonomies)
@@ -1687,7 +1672,7 @@ public class AlchemyLanguage {
         
         // execute request
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<DocumentText, NSError>) in
                 switch response.result {
                 case .Success(let docText): success(docText)
@@ -1734,7 +1719,7 @@ public class AlchemyLanguage {
         
         // execute request
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<DocumentText, NSError>) in
                 switch response.result {
                 case .Success(let docText): success(docText)
@@ -1783,7 +1768,7 @@ public class AlchemyLanguage {
         
         // execute request
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<DocumentText, NSError>) in
                 switch response.result {
                 case .Success(let docText): success(docText)
@@ -1840,7 +1825,7 @@ public class AlchemyLanguage {
         
         // execute request
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<DocumentText, NSError>) in
                 switch response.result {
                 case .Success(let docText): success(docText)
@@ -1883,7 +1868,7 @@ public class AlchemyLanguage {
         
         // execute request
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<DocumentTitle, NSError>) in
                 switch response.result {
                 case .Success(let docTitle): success(docTitle)
@@ -1934,7 +1919,7 @@ public class AlchemyLanguage {
         
         // execute request
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<DocumentTitle, NSError>) in
                 switch response.result {
                 case .Success(let docTitle): success(docTitle)
@@ -1970,7 +1955,7 @@ public class AlchemyLanguage {
         
         // execute request
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<Feeds, NSError>) in
                 switch response.result {
                 case .Success(let feeds): success(feeds)
@@ -2018,7 +2003,7 @@ public class AlchemyLanguage {
         
         // execute request
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<Feeds, NSError>) in
                 switch response.result {
                 case .Success(let feeds): success(feeds)
@@ -2054,7 +2039,7 @@ public class AlchemyLanguage {
         
         // execute request
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<DocumentEmotion, NSError>) in
                 switch response.result {
                 case .Success(let emotion): success(emotion)
@@ -2102,7 +2087,7 @@ public class AlchemyLanguage {
         
         // execute request
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<DocumentEmotion, NSError>) in
                 switch response.result {
                 case .Success(let emotion): success(emotion)
@@ -2145,7 +2130,7 @@ public class AlchemyLanguage {
         
         // execute request
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<DocumentEmotion, NSError>) in
                 switch response.result {
                 case .Success(let emotion): success(emotion)

--- a/Source/AlchemyVisionV1/AlchemyVision.swift
+++ b/Source/AlchemyVisionV1/AlchemyVision.swift
@@ -44,32 +44,6 @@ public class AlchemyVision {
     public init(apiKey: String) {
         self.apiKey = apiKey
     }
-    
-    /**
-     If the given data represents an error returned by the Alchemy Vision service, then return
-     an NSError with information about the error that occured. Otherwise, return nil.
-     
-     - parameter data: Raw data returned from the service that may represent an error.
-     */
-    
-    private func dataToError(data: NSData) -> NSError? {
-        do {
-            let json = try JSON(data: data)
-            let status = try json.string("status")
-            let statusInfo = try json.string("statusInfo")
-            if status == "OK" {
-                return nil
-            } else {
-                let userInfo = [
-                    NSLocalizedFailureReasonErrorKey: status,
-                    NSLocalizedDescriptionKey: statusInfo
-                ]
-                return NSError(domain: domain, code: 400, userInfo: userInfo)
-            }
-        } catch {
-            return nil
-        }
-    }
 
     /**
      Perform face recognition on an uploaded image. For each face detected, the service returns
@@ -112,7 +86,7 @@ public class AlchemyVision {
         
         // execute REST request
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) { (response: Response<FaceTags, NSError>) in
+            .responseObject() { (response: Response<FaceTags, NSError>) in
                 switch response.result {
                 case .Success(let faceTags): success(faceTags)
                 case .Failure(let error): failure?(error)
@@ -161,7 +135,7 @@ public class AlchemyVision {
 
         // execute REST request
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) { (response: Response<FaceTags, NSError>) in
+            .responseObject() { (response: Response<FaceTags, NSError>) in
                 switch response.result {
                 case .Success(let faceTags): success(faceTags)
                 case .Failure(let error): failure?(error)
@@ -246,7 +220,7 @@ public class AlchemyVision {
 
         // execute REST request
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) { (response: Response<ImageLink, NSError>) in
+            .responseObject() { (response: Response<ImageLink, NSError>) in
                 switch response.result {
                 case.Success(let imageLinks): success(imageLinks)
                 case .Failure(let error): failure?(error)
@@ -283,7 +257,7 @@ public class AlchemyVision {
 
         // execute REST request
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) { (response: Response<ImageLink, NSError>) in
+            .responseObject() { (response: Response<ImageLink, NSError>) in
                 switch response.result {
                 case .Success(let imageLinks): success(imageLinks)
                 case .Failure(let error): failure?(error)
@@ -340,7 +314,7 @@ public class AlchemyVision {
         
         // execute REST request
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) { (response: Response<ImageKeywords, NSError>) in
+            .responseObject() { (response: Response<ImageKeywords, NSError>) in
                 switch response.result {
                 case .Success(let imageKeywords): success(imageKeywords)
                 case .Failure(let error): failure?(error)
@@ -395,7 +369,7 @@ public class AlchemyVision {
 
         // execute REST request
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) { (response: Response<ImageKeywords, NSError>) in
+            .responseObject() { (response: Response<ImageKeywords, NSError>) in
                 switch response.result {
                 case .Success(let imageKeywords): success(imageKeywords)
                 case .Failure(let error): failure?(error)
@@ -434,7 +408,7 @@ public class AlchemyVision {
         
         // execute REST requeset
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) { (response: Response<SceneText, NSError>) in
+            .responseObject() { (response: Response<SceneText, NSError>) in
                 switch response.result {
                 case .Success(let sceneTexts): success(sceneTexts)
                 case .Failure(let error): failure?(error)
@@ -471,7 +445,7 @@ public class AlchemyVision {
 
         // execute REST requeset
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) { (response: Response<SceneText, NSError>) in
+            .responseObject() { (response: Response<SceneText, NSError>) in
                 switch response.result {
                 case .Success(let sceneTexts): success(sceneTexts)
                 case .Failure(let error): failure?(error)

--- a/Source/ConversationV1/Conversation.swift
+++ b/Source/ConversationV1/Conversation.swift
@@ -53,24 +53,6 @@ public class Conversation {
     }
     
     /**
-     If the given data represents an error returned by the Visual Recognition service, then return
-     an NSError with information about the error that occured. Otherwise, return nil.
-     
-     - parameter data: Raw data returned from the service that may represent an error.
-     */
-    private func dataToError(data: NSData) -> NSError? {
-        do {
-            let json = try JSON(data: data)
-            let error = try json.string("error")
-            let code = (try? json.int("code")) ?? 400
-            let userInfo = [NSLocalizedFailureReasonErrorKey: error]
-            return NSError(domain: domain, code: code, userInfo: userInfo)
-        } catch {
-            return nil
-        }
-    }
-    
-    /**
      Start a new conversation or get a response to a user's input.
      
      - parameter workspaceID: The unique identifier of the workspace to use.
@@ -150,7 +132,7 @@ public class Conversation {
         // execute REST request
         Alamofire.request(request)
             .authenticate(user: username, password: password)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<MessageResponse, NSError>) in
                 switch response.result {
                 case .Success(let response): success(response)

--- a/Source/ConversationV1Experimental/Conversation.swift
+++ b/Source/ConversationV1Experimental/Conversation.swift
@@ -53,24 +53,6 @@ public class Conversation {
     }
     
     /**
-     If the given data represents an error returned by the Visual Recognition service, then return
-     an NSError with information about the error that occured. Otherwise, return nil.
-     
-     - parameter data: Raw data returned from the service that may represent an error.
-     */
-    private func dataToError(data: NSData) -> NSError? {
-        do {
-            let json = try JSON(data: data)
-            let error = try json.string("error")
-            let code = (try? json.int("code")) ?? 400
-            let userInfo = [NSLocalizedFailureReasonErrorKey: error]
-            return NSError(domain: domain, code: code, userInfo: userInfo)
-        } catch {
-            return nil
-        }
-    }
-    
-    /**
      Get a response to a user's input.
      
      - parameter workspaceID: The unique identifier of the workspace to use.
@@ -114,7 +96,7 @@ public class Conversation {
         // execute REST request
         Alamofire.request(request)
             .authenticate(user: username, password: password)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<MessageResponse, NSError>) in
                 switch response.result {
                 case .Success(let response): success(response)

--- a/Source/DialogV1/Dialog.swift
+++ b/Source/DialogV1/Dialog.swift
@@ -53,7 +53,7 @@ public class Dialog {
         self.username = username
         self.password = password
     }
-
+    
     /**
      If the given data represents an error returned by the Visual Recognition service, then return
      an NSError with information about the error that occured. Otherwise, return nil.
@@ -95,7 +95,7 @@ public class Dialog {
         // execute REST request
         Alamofire.request(request)
             .authenticate(user: username, password: password)
-            .responseArray(dataToError: dataToError, path: ["dialogs"]) {
+            .responseArray(path: ["dialogs"]) {
                 (response: Response<[DialogModel], NSError>) in
                 switch response.result {
                 case .Success(let dialogs): success(dialogs)
@@ -147,7 +147,7 @@ public class Dialog {
                 switch encodingResult {
                 case .Success(let upload, _, _):
                     upload.authenticate(user: self.username, password: self.password)
-                    upload.responseObject(dataToError: self.dataToError, path: ["dialog_id"]) {
+                    upload.responseObject(path: ["dialog_id"]) {
                         (response: Response<DialogID, NSError>) in
                         switch response.result {
                         case .Success(let dialogID): success(dialogID)
@@ -393,7 +393,7 @@ public class Dialog {
         // execute REST request
         Alamofire.request(request)
             .authenticate(user: username, password: password)
-            .responseArray(dataToError: dataToError, path: ["items"]) {
+            .responseArray(path: ["items"]) {
                 (response: Response<[Node], NSError>) in
                 switch response.result {
                 case .Success(let nodes): success(nodes)
@@ -502,7 +502,7 @@ public class Dialog {
         // execute REST request
         Alamofire.request(request)
             .authenticate(user: username, password: password)
-            .responseArray(dataToError: dataToError, path: ["conversations"]) {
+            .responseArray(path: ["conversations"]) {
                 (response: Response<[Conversation], NSError>) in
                 switch response.result {
                 case .Success(let conversations): success(conversations)
@@ -556,7 +556,7 @@ public class Dialog {
         // execute REST request
         Alamofire.request(request)
             .authenticate(user: username, password: password)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<ConversationResponse, NSError>) in
                 switch response.result {
                 case .Success(let response): success(response)
@@ -605,7 +605,7 @@ public class Dialog {
         // execute REST request
         Alamofire.request(request)
             .authenticate(user: username, password: password)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<Profile, NSError>) in
                 switch response.result {
                 case .Success(let profile): success(profile)

--- a/Source/LanguageTranslatorV2/LanguageTranslator.swift
+++ b/Source/LanguageTranslatorV2/LanguageTranslator.swift
@@ -108,7 +108,7 @@ public class LanguageTranslator {
         // execute REST request
         Alamofire.request(request)
             .authenticate(user: username, password: password)
-            .responseArray(dataToError: dataToError, path: ["models"]) {
+            .responseArray(path: ["models"]) {
                 (response: Response<[TranslationModel], NSError>) in
                 switch response.result {
                 case .Success(let models): success(models)
@@ -165,7 +165,7 @@ public class LanguageTranslator {
                 switch encodingResult {
                 case .Success(let upload, _, _):
                     upload.authenticate(user: self.username, password: self.password)
-                    upload.responseObject(dataToError: self.dataToError, path: ["model_id"]) {
+                    upload.responseObject(path: ["model_id"]) {
                         (response: Response<String, NSError>) in
                         switch response.result {
                         case .Success(let modelID): success(modelID)
@@ -242,7 +242,7 @@ public class LanguageTranslator {
         // execute REST request
         Alamofire.request(request)
             .authenticate(user: username, password: password)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<MonitorTraining, NSError>) in
                 switch response.result {
                 case .Success(let monitorTraining): success(monitorTraining)
@@ -372,7 +372,7 @@ public class LanguageTranslator {
         // execute REST request
         Alamofire.request(request)
             .authenticate(user: username, password: password)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<TranslateResponse, NSError>) in
                 switch response.result {
                 case .Success(let translateResponse): success(translateResponse)
@@ -404,7 +404,7 @@ public class LanguageTranslator {
         // execute REST request
         Alamofire.request(request)
             .authenticate(user: username, password: password)
-            .responseArray(dataToError: dataToError, path: ["languages"]) {
+            .responseArray(path: ["languages"]) {
                 (response: Response<[IdentifiableLanguage], NSError>) in
                 switch response.result {
                 case .Success(let languages): success(languages)
@@ -447,7 +447,7 @@ public class LanguageTranslator {
         // execute REST request
         Alamofire.request(request)
             .authenticate(user: username, password: password)
-            .responseArray(dataToError: dataToError, path: ["languages"]) {
+            .responseArray(path: ["languages"]) {
                 (response: Response<[IdentifiedLanguage], NSError>) in
                 switch response.result {
                 case .Success(let languages): success(languages)

--- a/Source/NaturalLanguageClassifierV1/NaturalLanguageClassifier.swift
+++ b/Source/NaturalLanguageClassifierV1/NaturalLanguageClassifier.swift
@@ -91,7 +91,7 @@ public class NaturalLanguageClassifier {
         // execute REST request
         Alamofire.request(request)
             .authenticate(user: username, password: password)
-            .responseArray(dataToError: dataToError, path: ["classifiers"]) {
+            .responseArray(path: ["classifiers"]) {
                 (response: Response<[ClassifierModel], NSError>) in
                 switch response.result {
                 case .Success(let classifiers): success(classifiers)
@@ -136,8 +136,7 @@ public class NaturalLanguageClassifier {
                 switch encodingResult {
                 case .Success(let upload, _, _):
                     upload.authenticate(user: self.username, password: self.password)
-                    upload.responseObject(dataToError: self.dataToError) {
-                        (response: Response<ClassifierDetails, NSError>) in
+                    upload.responseObject() { (response: Response<ClassifierDetails, NSError>) in
                         switch response.result {
                         case .Success(let classifierDetails): success(classifierDetails)
                         case .Failure(let error): failure?(error)
@@ -191,7 +190,7 @@ public class NaturalLanguageClassifier {
         // execute REST request
         Alamofire.request(request)
             .authenticate(user: username, password: password)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<Classification, NSError>) in
                 switch response.result {
                 case .Success(let classification): success(classification)
@@ -259,7 +258,7 @@ public class NaturalLanguageClassifier {
         // execute REST request
         Alamofire.request(request)
             .authenticate(user: username, password: password)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<ClassifierDetails, NSError>) in
                 switch response.result {
                 case .Success(let classifier): success(classifier)

--- a/Source/PersonalityInsightsV2/PersonalityInsights.swift
+++ b/Source/PersonalityInsightsV2/PersonalityInsights.swift
@@ -46,28 +46,6 @@ public class PersonalityInsights {
     }
 
     /**
-     If the given data represents an error returned by the Visual Recognition service, then return
-     an NSError with information about the error that occured. Otherwise, return nil.
-     
-     - parameter data: Raw data returned from the service that may represent an error.
-     */
-    private func dataToError(data: NSData) -> NSError? {
-        do {
-            let json = try JSON(data: data)
-            let code = try json.int("code")
-            let error = try json.string("error")
-            let help = try json.string("help")
-            let userInfo = [
-                NSLocalizedFailureReasonErrorKey: error,
-                NSLocalizedRecoverySuggestionErrorKey: help
-            ]
-            return NSError(domain: domain, code: code, userInfo: userInfo)
-        } catch {
-            return nil
-        }
-    }
-
-    /**
      Analyze text to generate a personality profile.
  
      - parameter text: The text to analyze.
@@ -239,7 +217,7 @@ public class PersonalityInsights {
         // execute REST request
         Alamofire.request(request)
             .authenticate(user: username, password: password)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<Profile, NSError>) in
                 switch response.result {
                 case .Success(let profile): success(profile)

--- a/Source/RelationshipExtractionV1Beta/RelationshipExtraction.swift
+++ b/Source/RelationshipExtractionV1Beta/RelationshipExtraction.swift
@@ -50,26 +50,6 @@ public class RelationshipExtraction {
     }
     
     /**
-     If the given data represents an error returned by the Relationship Extraction service, then 
-     return an NSError with information about the error that occured. Otherwise, return nil.
-     
-     - parameter data: Raw data returned from the service that may represent an error.
-     */
-    private func dataToError(data: NSData) -> NSError? {
-        do {
-            let json = try JSON(data: data)
-            let code = try json.int("error_code")
-            let error = try json.string("error_message")
-            let userInfo = [
-                NSLocalizedFailureReasonErrorKey: error,
-            ]
-            return NSError(domain: domain, code: code, userInfo: userInfo)
-        } catch {
-            return nil
-        }
-    }
-    
-    /**
      Analyzes a piece of text and extracts the different entities, along with the relationships that 
      exist between those entities.
      
@@ -102,7 +82,7 @@ public class RelationshipExtraction {
         // execute REST request
         Alamofire.request(request)
             .authenticate(user: username, password: password)
-            .responseObject(dataToError: dataToError, path: ["doc"]) {
+            .responseObject(path: ["doc"]) {
                 (response: Response<Document, NSError>) in
                 switch response.result {
                 case .Success(let document): success(document)

--- a/Source/RetrieveAndRankV1/RetrieveAndRank.swift
+++ b/Source/RetrieveAndRankV1/RetrieveAndRank.swift
@@ -97,7 +97,7 @@ public class RetrieveAndRank {
         // execute REST request
         Alamofire.request(request)
             .authenticate(user: username, password: password)
-            .responseArray(dataToError: dataToError, path: ["clusters"]) {
+            .responseArray(path: ["clusters"]) {
                 (response: Response<[SolrCluster], NSError>) in
                 switch response.result {
                 case .Success(let clusters): success(clusters)
@@ -149,7 +149,7 @@ public class RetrieveAndRank {
         // execute REST request
         Alamofire.request(request)
             .authenticate(user: username, password: password)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<SolrCluster, NSError>) in
                 switch response.result {
                 case .Success(let cluster): success(cluster)
@@ -216,7 +216,7 @@ public class RetrieveAndRank {
         // execute REST request
         Alamofire.request(request)
             .authenticate(user: username, password: password)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<SolrCluster, NSError>) in
                 switch response.result {
                 case .Success(let cluster): success(cluster)
@@ -249,7 +249,7 @@ public class RetrieveAndRank {
         // execute REST request
         Alamofire.request(request)
             .authenticate(user: username, password: password)
-            .responseArray(dataToError: dataToError, path: ["solr_configs"]) {
+            .responseArray(path: ["solr_configs"]) {
                 (response: Response<[String], NSError>) in
                 switch response.result {
                 case .Success(let config): success(config)
@@ -548,7 +548,7 @@ public class RetrieveAndRank {
         // execute REST request
         Alamofire.request(request)
             .authenticate(user: username, password: password)
-            .responseArray(dataToError: dataToError, path: ["collections"]) {
+            .responseArray(path: ["collections"]) {
                 (response: Response<[String], NSError>) in
                 switch response.result {
                 case .Success(let collections): success(collections)
@@ -662,7 +662,7 @@ public class RetrieveAndRank {
         // execute REST request
         Alamofire.request(request)
             .authenticate(user: username, password: password)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<SearchResponse, NSError>) in
                 switch response.result {
                 case .Success(let response): success(response)
@@ -716,7 +716,7 @@ public class RetrieveAndRank {
         // execute REST request
         Alamofire.request(request)
             .authenticate(user: username, password: password)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<SearchAndRankResponse, NSError>) in
                 switch response.result {
                 case .Success(let response): success(response)
@@ -748,7 +748,7 @@ public class RetrieveAndRank {
         // execute REST request
         Alamofire.request(request)
             .authenticate(user: username, password: password)
-            .responseArray(dataToError: dataToError, path: ["rankers"]) {
+            .responseArray(path: ["rankers"]) {
                 (response: Response<[Ranker], NSError>) in
                 switch response.result {
                 case .Success(let rankers): success(rankers)
@@ -806,7 +806,7 @@ public class RetrieveAndRank {
                 switch encodingResult {
                 case .Success(let upload, _, _):
                     upload.authenticate(user: self.username, password: self.password)
-                    upload.responseObject(dataToError: self.dataToError) {
+                    upload.responseObject() {
                         (response: Response<RankerDetails, NSError>) in
                         switch response.result {
                         case .Success(let ranker): success(ranker)
@@ -860,7 +860,7 @@ public class RetrieveAndRank {
                 switch encodingResult {
                 case .Success(let upload, _, _):
                     upload.authenticate(user: self.username, password: self.password)
-                    upload.responseObject(dataToError: self.dataToError) {
+                    upload.responseObject() {
                         (response: Response<Ranking, NSError>) in
                         switch response.result {
                         case .Success(let ranking): success(ranking)
@@ -936,7 +936,7 @@ public class RetrieveAndRank {
         // execute REST request
         Alamofire.request(request)
             .authenticate(user: username, password: password)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<RankerDetails, NSError>) in
                 switch response.result {
                 case .Success(let details): success(details)

--- a/Source/SpeechToTextV1/SpeechToText.swift
+++ b/Source/SpeechToTextV1/SpeechToText.swift
@@ -98,7 +98,7 @@ public class SpeechToText {
         // execute REST request
         Alamofire.request(request)
             .authenticate(user: username, password: password)
-            .responseArray(dataToError: dataToError, path: ["models"]) {
+            .responseArray(path: ["models"]) {
                 (response: Response<[Model], NSError>) in
                 switch response.result {
                 case .Success(let models): success(models)
@@ -125,7 +125,7 @@ public class SpeechToText {
         // execute REST request
         Alamofire.request(request)
             .authenticate(user: username, password: password)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<Model, NSError>) in
                 switch response.result {
                 case .Success(let model): success(model)

--- a/Source/TextToSpeechV1/TextToSpeech.swift
+++ b/Source/TextToSpeechV1/TextToSpeech.swift
@@ -89,7 +89,7 @@ public class TextToSpeech {
         // execute REST request
         Alamofire.request(request)
             .authenticate(user: username, password: password)
-            .responseArray(dataToError: dataToError, path: ["voices"]) {
+            .responseArray(path: ["voices"]) {
                 (response: Response<[Voice], NSError>) in
                 switch response.result {
                 case .Success(let voices): success(voices)
@@ -136,7 +136,7 @@ public class TextToSpeech {
         // execute REST request
         Alamofire.request(request)
             .authenticate(user: username, password: password)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<Voice, NSError>) in
                 switch response.result {
                 case .Success(let voice): success(voice)
@@ -191,7 +191,7 @@ public class TextToSpeech {
         // execute REST request
         Alamofire.request(request)
             .authenticate(user: username, password: password)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<Pronunciation, NSError>) in
                 switch response.result {
                 case .Success(let voice): success(voice)
@@ -309,7 +309,7 @@ public class TextToSpeech {
         // execute REST request
         Alamofire.request(request)
             .authenticate(user: username, password: password)
-            .responseArray(dataToError: dataToError, path: ["customizations"]) {
+            .responseArray(path: ["customizations"]) {
                 (response: Response<[Customization], NSError>) in
                 switch response.result {
                 case .Success(let customizations): success(customizations)
@@ -364,7 +364,7 @@ public class TextToSpeech {
         // execute REST request
         Alamofire.request(request)
             .authenticate(user: username, password: password)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<CustomizationID, NSError>) in
                 switch response.result {
                 case .Success(let customizationID): success(customizationID)
@@ -432,7 +432,7 @@ public class TextToSpeech {
         // execute REST request
         Alamofire.request(request)
             .authenticate(user: username, password: password)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<CustomizationWords, NSError>) in
                 switch response.result {
                 case .Success(let customizationWords): success(customizationWords)
@@ -521,7 +521,7 @@ public class TextToSpeech {
         // execute the request
         Alamofire.request(request)
             .authenticate(user: username, password: password)
-            .responseArray(dataToError: dataToError, path: ["words"]) {
+            .responseArray(path: ["words"]) {
                 (response: Response<[Word], NSError>) in
                 switch response.result {
                 case .Success(let words): success(words)
@@ -642,7 +642,7 @@ public class TextToSpeech {
         // execute the request
         Alamofire.request(request)
             .authenticate(user: username, password: password)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<Translation, NSError>) in
                 switch response.result {
                 case .Success(let translation): success(translation)

--- a/Source/ToneAnalyzerV3/ToneAnalyzer.swift
+++ b/Source/ToneAnalyzerV3/ToneAnalyzer.swift
@@ -48,28 +48,6 @@ public class ToneAnalyzer {
         self.password = password
         self.version = version
     }
-    
-    /**
-     If the given data represents an error returned by the Visual Recognition service, then return
-     an NSError with information about the error that occured. Otherwise, return nil.
-     
-     - parameter data: Raw data returned from the service that may represent an error.
-     */
-    private func dataToError(data: NSData) -> NSError? {
-        do {
-            let json = try JSON(data: data)
-            let code = try json.int("code")
-            let error = try json.string("error")
-            let help = try? json.string("help")
-            let userInfo = [
-                NSLocalizedFailureReasonErrorKey: error,
-                NSLocalizedRecoverySuggestionErrorKey: "\(help)"
-            ]
-            return NSError(domain: domain, code: code, userInfo: userInfo)
-        } catch {
-            return nil
-        }
-    }
 
     /**
      Analyze the tone of the given text.
@@ -125,7 +103,7 @@ public class ToneAnalyzer {
         // execute REST request
         Alamofire.request(request)
             .authenticate(user: username, password: password)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<ToneAnalysis, NSError>) in
                 switch response.result {
                 case .Success(let toneAnalysis): success(toneAnalysis)

--- a/Source/VisualRecognitionV3/VisualRecognition.swift
+++ b/Source/VisualRecognitionV3/VisualRecognition.swift
@@ -96,7 +96,7 @@ public class VisualRecognition {
         
         // execute REST request
         Alamofire.request(request)
-            .responseArray(dataToError: dataToError, path: ["classifiers"]) {
+            .responseArray(path: ["classifiers"]) {
                 (response: Response<[Classifier], NSError>) in
                 switch response.result {
                 case .Success(let classifiers): success(classifiers)
@@ -177,7 +177,7 @@ public class VisualRecognition {
             encodingCompletion: { encodingResult in
                 switch encodingResult {
                 case .Success(let upload, _, _):
-                    upload.responseObject(dataToError: self.dataToError) {
+                    upload.responseObject() {
                         (response: Response<Classifier, NSError>) in
                         switch response.result {
                         case .Success(let classifier): success(classifier)
@@ -264,7 +264,7 @@ public class VisualRecognition {
         
         // execute REST request
         Alamofire.request(request)
-            .responseObject(dataToError: dataToError) {
+            .responseObject() {
                 (response: Response<Classifier, NSError>) in
                 switch response.result {
                 case .Success(let classifier): success(classifier)
@@ -339,7 +339,7 @@ public class VisualRecognition {
             encodingCompletion: { encodingResult in
                 switch encodingResult {
                 case .Success(let upload, _, _):
-                    upload.responseObject(dataToError: self.dataToError) {
+                    upload.responseObject() {
                         (response: Response<Classifier, NSError>) in
                         switch response.result {
                         case .Success(let classifier): success(classifier)
@@ -499,7 +499,7 @@ public class VisualRecognition {
             encodingCompletion: { encodingResult in
                 switch encodingResult {
                 case .Success(let upload, _, _):
-                    upload.responseObject(dataToError: self.dataToError) {
+                    upload.responseObject() {
                         (response: Response<ClassifiedImages, NSError>) in
                         switch response.result {
                         case .Success(let classifiedImages): success(classifiedImages)
@@ -582,7 +582,7 @@ public class VisualRecognition {
             encodingCompletion: { encodingResult in
                 switch encodingResult {
                 case .Success(let upload, _, _):
-                    upload.responseObject(dataToError: self.dataToError) {
+                    upload.responseObject() {
                         (response: Response<ImagesWithFaces, NSError>) in
                         switch response.result {
                         case .Success(let faceImages): success(faceImages)
@@ -664,7 +664,7 @@ public class VisualRecognition {
             encodingCompletion: { encodingResult in
                 switch encodingResult {
                 case .Success(let upload, _, _):
-                    upload.responseObject(dataToError: self.dataToError) {
+                    upload.responseObject() {
                         (response: Response<ImagesWithWords, NSError>) in
                         switch response.result {
                         case .Success(let wordImages): success(wordImages)


### PR DESCRIPTION
This pull request updates error handling in RestKit to avoid the use of a `dataToError` function. Instead, any error response is turned into a `String` and included in an `NSError` object.

I removed the `dataToError` function from services where I could. But some services do use the function to check whether an error occurred (for example, when an endpoint would normally return no response, but returns data in the response when an error occurs).