### PR TITLE
Renaming Dialog methods according to Swift 3.0 convention

### DIFF
--- a/Source/DialogV1/Dialog.swift
+++ b/Source/DialogV1/Dialog.swift
@@ -216,7 +216,7 @@ public class Dialog {
      - parameter success: A function executed with the URL of the downloaded dialog file.
      */
     public func getDialogFile(
-        forDialogID dialogID: DialogID,
+        withDialogID dialogID: DialogID,
         inFormat format: Format? = nil,
         failure: ((Error) -> Void)? = nil,
         success: @escaping (URL) -> Void)
@@ -372,7 +372,7 @@ public class Dialog {
      - parameter success: A function executed with the dialog application's nodes.
      */
     public func getContent(
-        ofDialogID dialogID: DialogID,
+        fromDialogID dialogID: DialogID,
         failure: ((Error) -> Void)? = nil,
         success: @escaping ([Node]) -> Void)
     {
@@ -404,7 +404,7 @@ public class Dialog {
      - parameter success: A function executed after the specified nodes have been updated.
      */
     public func updateContent(
-        ofDialogID dialogID: DialogID,
+        fromDialogID dialogID: DialogID,
         forNodes nodes: [Node],
         failure: ((Error) -> Void)? = nil,
         success: ((Void) -> Void)? = nil)
@@ -460,7 +460,7 @@ public class Dialog {
      - parameter success: A function executed with the retrieved conversation history.
      */
     public func getConversationHistory(
-        forDialogID dialogID: DialogID,
+        fromDialogID dialogID: DialogID,
         from dateFrom: Date,
         to dateTo: Date,
         offset: Int? = nil,
@@ -517,7 +517,7 @@ public class Dialog {
      - parameter success: A function executed with the dialog application's response.
      */
     public func converse(
-        usingDialogID dialogID: DialogID,
+        withDialogID dialogID: DialogID,
         withConversationID conversationID: Int? = nil,
         clientID: Int? = nil,
         input: String? = nil,
@@ -569,7 +569,7 @@ public class Dialog {
      - parameter success: A function executed with the retrieved profile variables.
      */
     public func getProfile(
-        inDialogID dialogID: DialogID,
+        fromDialogID dialogID: DialogID,
         withClientID clientID: Int,
         names: [String]? = nil,
         failure: ((Error) -> Void)? = nil,
@@ -616,7 +616,7 @@ public class Dialog {
      - parameter success: A function executed after the client's profile has been updated.
      */
     public func updateProfile(
-        inDialogID dialogID: DialogID,
+        fromDialogID dialogID: DialogID,
         withClientID clientID: Int? = nil,
         parameters: [String: String],
         failure: ((Error) -> Void)? = nil,

--- a/Source/DialogV1/Dialog.swift
+++ b/Source/DialogV1/Dialog.swift
@@ -124,8 +124,8 @@ public class Dialog {
         application.
      */
     public func createDialog(
-        name: String,
-        fileURL: URL,
+        withName name: String,
+        fromFile fileURL: URL,
         failure: ((Error) -> Void)? = nil,
         success: @escaping (DialogID) -> Void)
     {
@@ -177,7 +177,7 @@ public class Dialog {
         has been successfully deleted.
      */
     public func deleteDialog(
-        dialogID: DialogID,
+        withID dialogID: DialogID,
         failure: ((Error) -> Void)? = nil,
         success: ((Void) -> Void)? = nil)
     {
@@ -216,8 +216,8 @@ public class Dialog {
      - parameter success: A function executed with the URL of the downloaded dialog file.
      */
     public func getDialogFile(
-        dialogID: DialogID,
-        format: Format? = nil,
+        for dialogID: DialogID,
+        inFormat format: Format? = nil,
         failure: ((Error) -> Void)? = nil,
         success: @escaping (URL) -> Void)
     {
@@ -317,8 +317,8 @@ public class Dialog {
         successfully uploaded.
      */
     public func updateDialog(
-        dialogID: DialogID,
-        fileURL: URL,
+        for dialogID: DialogID,
+        fromFile fileURL: URL,
         failure: ((Error) -> Void)? = nil,
         success: ((Void) -> Void)? = nil)
     {
@@ -372,7 +372,7 @@ public class Dialog {
      - parameter success: A function executed with the dialog application's nodes.
      */
     public func getContent(
-        dialogID: DialogID,
+        fromDialog dialogID: DialogID,
         failure: ((Error) -> Void)? = nil,
         success: @escaping ([Node]) -> Void)
     {

--- a/Source/DialogV1/Dialog.swift
+++ b/Source/DialogV1/Dialog.swift
@@ -216,7 +216,7 @@ public class Dialog {
      - parameter success: A function executed with the URL of the downloaded dialog file.
      */
     public func getDialogFile(
-        withDialogID dialogID: DialogID,
+        fromDialogID dialogID: DialogID,
         inFormat format: Format? = nil,
         failure: ((Error) -> Void)? = nil,
         success: @escaping (URL) -> Void)

--- a/Source/DialogV1/Dialog.swift
+++ b/Source/DialogV1/Dialog.swift
@@ -216,7 +216,7 @@ public class Dialog {
      - parameter success: A function executed with the URL of the downloaded dialog file.
      */
     public func getDialogFile(
-        for dialogID: DialogID,
+        forDialogID dialogID: DialogID,
         inFormat format: Format? = nil,
         failure: ((Error) -> Void)? = nil,
         success: @escaping (URL) -> Void)
@@ -233,9 +233,9 @@ public class Dialog {
         var filetype = ".mct"
         if let format = format {
             switch format {
-            case .OctetStream: filetype = ".mct"
-            case .WDSJSON: filetype = ".json"
-            case .WDSXML: filetype = ".xml"
+            case .octetStream: filetype = ".mct"
+            case .wdsJSON: filetype = ".json"
+            case .wdsXML: filetype = ".xml"
             }
         }
         
@@ -317,7 +317,7 @@ public class Dialog {
         successfully uploaded.
      */
     public func updateDialog(
-        for dialogID: DialogID,
+        withID dialogID: DialogID,
         fromFile fileURL: URL,
         failure: ((Error) -> Void)? = nil,
         success: ((Void) -> Void)? = nil)
@@ -372,7 +372,7 @@ public class Dialog {
      - parameter success: A function executed with the dialog application's nodes.
      */
     public func getContent(
-        fromDialog dialogID: DialogID,
+        ofDialogID dialogID: DialogID,
         failure: ((Error) -> Void)? = nil,
         success: @escaping ([Node]) -> Void)
     {
@@ -404,8 +404,8 @@ public class Dialog {
      - parameter success: A function executed after the specified nodes have been updated.
      */
     public func updateContent(
-        dialogID: DialogID,
-        nodes: [Node],
+        ofDialogID dialogID: DialogID,
+        forNodes nodes: [Node],
         failure: ((Error) -> Void)? = nil,
         success: ((Void) -> Void)? = nil)
     {
@@ -460,9 +460,9 @@ public class Dialog {
      - parameter success: A function executed with the retrieved conversation history.
      */
     public func getConversationHistory(
-        dialogID: DialogID,
-        dateFrom: Date,
-        dateTo: Date,
+        forDialogID dialogID: DialogID,
+        from dateFrom: Date,
+        to dateTo: Date,
         offset: Int? = nil,
         limit: Int? = nil,
         failure: ((Error) -> Void)? = nil,
@@ -517,8 +517,8 @@ public class Dialog {
      - parameter success: A function executed with the dialog application's response.
      */
     public func converse(
-        dialogID: DialogID,
-        conversationID: Int? = nil,
+        usingDialogID dialogID: DialogID,
+        withConversationID conversationID: Int? = nil,
         clientID: Int? = nil,
         input: String? = nil,
         failure: ((Error) -> Void)? = nil,
@@ -569,8 +569,8 @@ public class Dialog {
      - parameter success: A function executed with the retrieved profile variables.
      */
     public func getProfile(
-        dialogID: DialogID,
-        clientID: Int,
+        inDialogID dialogID: DialogID,
+        withClientID clientID: Int,
         names: [String]? = nil,
         failure: ((Error) -> Void)? = nil,
         success: @escaping (Profile) -> Void)
@@ -616,8 +616,8 @@ public class Dialog {
      - parameter success: A function executed after the client's profile has been updated.
      */
     public func updateProfile(
-        dialogID: DialogID,
-        clientID: Int? = nil,
+        inDialogID dialogID: DialogID,
+        withClientID clientID: Int? = nil,
         parameters: [String: String],
         failure: ((Error) -> Void)? = nil,
         success: ((Void) -> Void)? = nil)

--- a/Source/DialogV1/Models/Format.swift
+++ b/Source/DialogV1/Models/Format.swift
@@ -20,7 +20,7 @@ import Foundation
 public enum Format: String {
     
     /// OctetStream Format (i.e. a binary file)
-    case OctetStream = "application/octet-stream"
+    case octetStream = "application/octet-stream"
     
     /// WDSJSON Format
     case WDSJSON = "application/wds+json"

--- a/Source/DialogV1/Models/Format.swift
+++ b/Source/DialogV1/Models/Format.swift
@@ -23,8 +23,8 @@ public enum Format: String {
     case octetStream = "application/octet-stream"
     
     /// WDSJSON Format
-    case WDSJSON = "application/wds+json"
+    case wdsJSON = "application/wds+json"
     
     /// WDSXML Format
-    case WDSXML = "application/wds+xml"
+    case wdsXML = "application/wds+xml"
 }

--- a/Source/DialogV1/Tests/DialogTests.swift
+++ b/Source/DialogV1/Tests/DialogTests.swift
@@ -85,7 +85,7 @@ class DialogTests: XCTestCase {
             XCTFail("Failed to create the test dialog application.")
         }
 
-        dialog.createDialog(name: dialogName, fileURL: fileURL, failure: failure) { id in
+        dialog.createDialog(withName: dialogName, fromFile: fileURL, failure: failure) { id in
             self.dialogID = id
             self.dialogName = dialogName
             expectation.fulfill()
@@ -174,7 +174,7 @@ class DialogTests: XCTestCase {
             return
         }
         
-        dialog.createDialog(name: dialogName, fileURL: fileURL, failure: failWithError) { id in
+        dialog.createDialog(withName: dialogName, fromFile: fileURL, failure: failWithError) { id in
             dialogID = id
             expectation1.fulfill()
         }
@@ -183,7 +183,7 @@ class DialogTests: XCTestCase {
         let description2 = "Delete the dialog application."
         let expectation2 = self.expectation(description: description2)
         
-        dialog.deleteDialog(dialogID: dialogID!, failure: failWithError) {
+        dialog.deleteDialog(withID: dialogID!, failure: failWithError) {
             expectation2.fulfill()
         }
         waitForExpectations()
@@ -194,7 +194,7 @@ class DialogTests: XCTestCase {
         let description = "Download the dialog file associated with the test application."
         let expectation = self.expectation(description: description)
         
-        dialog.getDialogFile(dialogID: dialogID!, format: format, failure: failWithError) { file in
+        dialog.getDialogFile(forDialogID: dialogID!, inFormat: format, failure: failWithError) { file in
             let fileManager = FileManager.default
             XCTAssertTrue(fileManager.fileExists(atPath: file.path))
             XCTAssertTrue(self.verifyFiletype(format: format, url: file))
@@ -209,9 +209,9 @@ class DialogTests: XCTestCase {
         var filetype = ".mct"
         if let format = format {
             switch format {
-            case .OctetStream: filetype = ".mct"
-            case .WDSJSON: filetype = ".json"
-            case .WDSXML: filetype = ".xml"
+            case .octetStream: filetype = ".mct"
+            case .wdsJSON: filetype = ".json"
+            case .wdsXML: filetype = ".xml"
             }
         }
         return url.path.hasSuffix(filetype)
@@ -224,17 +224,17 @@ class DialogTests: XCTestCase {
 
     /** Download the dialog file associated with the test application in OctetStream format. */
     func testGetDialogFileOctetStream() {
-        getDialogFile(format: .OctetStream)
+        getDialogFile(format: .octetStream)
     }
 
     /** Download the dialog file associated with the test application in JSON format. */
     func testGetDialogFileJSON() {
-        getDialogFile(format: .WDSJSON)
+        getDialogFile(format: .wdsJSON)
     }
 
     /** Download the dialog file associated with the test application in XML format. */
     func testGetDialogFileXML() {
-        getDialogFile(format: .WDSXML)
+        getDialogFile(format: .wdsXML)
     }
 
     /** Update the dialog application. */
@@ -247,7 +247,7 @@ class DialogTests: XCTestCase {
             return
         }
 
-        dialog.updateDialog(dialogID: dialogID!, fileURL: fileURL, failure: failWithError) {
+        dialog.updateDialog(withID: dialogID!, fromFile: fileURL, failure: failWithError) {
             expectation.fulfill()
         }
         waitForExpectations()
@@ -262,7 +262,7 @@ class DialogTests: XCTestCase {
         let initialResponse = "Hi, I\'m Watson! I can help you order a pizza, " +
                               "what size would you like?"
 
-        dialog.getContent(dialogID: dialogID!, failure: failWithError) { nodes in
+        dialog.getContent(ofDialogID: dialogID!, failure: failWithError) { nodes in
             for node in nodes {
                 let nodeMatch = (node.node == initialNode)
                 let contentMatch = (node.content == initialResponse)
@@ -287,7 +287,7 @@ class DialogTests: XCTestCase {
 
         let newNode = DialogV1.Node(content: newGreeting, node: initialNode)
 
-        dialog.updateContent(dialogID: dialogID!, nodes: [newNode], failure: failWithError) {
+        dialog.updateContent(ofDialogID: dialogID!, forNodes: [newNode], failure: failWithError) {
             expectation.fulfill()
         }
         waitForExpectations()
@@ -306,7 +306,7 @@ class DialogTests: XCTestCase {
         var conversationID: Int?
         var clientID: Int?
 
-        dialog.converse(dialogID: dialogID!, failure: failWithError) { response in
+        dialog.converse(usingDialogID: dialogID!, failure: failWithError) { response in
             XCTAssertEqual(response.response.last, response1)
             conversationID = response.conversationID
             clientID = response.clientID
@@ -319,7 +319,7 @@ class DialogTests: XCTestCase {
 
         let response2 = "What toppings are you in the mood for? (Limit 4)"
 
-        dialog.converse(dialogID: dialogID!, conversationID: conversationID!, clientID: clientID!, input: "large", failure: failWithError) {
+        dialog.converse(usingDialogID: dialogID!, withConversationID: conversationID!, clientID: clientID!, input: "large", failure: failWithError) {
             response in
             XCTAssertEqual(response.response.last, response2)
             expectation2.fulfill()
@@ -336,7 +336,7 @@ class DialogTests: XCTestCase {
         let dateFrom = Date(timeInterval: serverOffset - bufferOffset, since: startTime)
         let dateTo = Date(timeIntervalSinceNow: serverOffset + bufferOffset)
 
-        dialog.getConversationHistory(dialogID: dialogID!, dateFrom: dateFrom, dateTo: dateTo, failure: failWithError) {
+        dialog.getConversationHistory(forDialogID: dialogID!, from: dateFrom, to: dateTo, failure: failWithError) {
             conversations in
             XCTAssertGreaterThanOrEqual(conversations.count, 1)
             XCTAssertEqual(conversations.last?.messages.count, 3)
@@ -357,7 +357,7 @@ class DialogTests: XCTestCase {
         var conversationID: Int?
         var clientID: Int?
 
-        dialog.converse(dialogID: dialogID!, failure: failWithError) { response in
+        dialog.converse(usingDialogID: dialogID!, failure: failWithError) { response in
             XCTAssertEqual(response.response.last, response1)
             conversationID = response.conversationID
             clientID = response.clientID
@@ -370,7 +370,7 @@ class DialogTests: XCTestCase {
 
         let response2 = "What toppings are you in the mood for? (Limit 4)"
 
-        dialog.converse(dialogID: dialogID!, conversationID: conversationID!, clientID: clientID!, input: "large", failure: failWithError) {
+        dialog.converse(usingDialogID: dialogID!, withConversationID: conversationID!, clientID: clientID!, input: "large", failure: failWithError) {
             response in
             XCTAssertEqual(response.response.last, response2)
             expectation2.fulfill()
@@ -388,7 +388,7 @@ class DialogTests: XCTestCase {
         let dateTo = Date(timeIntervalSinceNow: serverOffset + bufferOffset)
 
         let offset = 1000
-        dialog.getConversationHistory(dialogID: dialogID!, dateFrom: dateFrom, dateTo: dateTo, offset: offset, failure: failWithError) {
+        dialog.getConversationHistory(forDialogID: dialogID!, from: dateFrom, to: dateTo, offset: offset, failure: failWithError) {
             conversations in
             XCTAssertEqual(conversations.count, 0)
             expectation3.fulfill()
@@ -406,7 +406,7 @@ class DialogTests: XCTestCase {
         var conversationID: Int?
         var clientID: Int?
 
-        dialog.converse(dialogID: dialogID!, failure: failWithError) { response in
+        dialog.converse(usingDialogID: dialogID!, failure: failWithError) { response in
             XCTAssertEqual(response.response.last, response1)
             conversationID = response.conversationID
             clientID = response.clientID
@@ -419,7 +419,7 @@ class DialogTests: XCTestCase {
 
         let response2 = "What toppings are you in the mood for? (Limit 4)"
 
-        dialog.converse(dialogID: dialogID!, conversationID: conversationID!, clientID: clientID!, input: "large", failure: failWithError) {
+        dialog.converse(usingDialogID: dialogID!, withConversationID: conversationID!, clientID: clientID!, input: "large", failure: failWithError) {
             response in
             XCTAssertEqual(response.response.last, response2)
             expectation2.fulfill()
@@ -437,7 +437,7 @@ class DialogTests: XCTestCase {
         let dateTo = Date(timeIntervalSinceNow: serverOffset + bufferOffset)
 
         let limit = 0
-        dialog.getConversationHistory(dialogID: dialogID!, dateFrom: dateFrom, dateTo: dateTo, limit: limit, failure: failWithError) {
+        dialog.getConversationHistory(forDialogID: dialogID!, from: dateFrom, to: dateTo, limit: limit, failure: failWithError) {
             conversations in
             // XCTAssertEqual(conversations.count, 0)
             expectation3.fulfill()
@@ -455,7 +455,7 @@ class DialogTests: XCTestCase {
         var conversationID: Int?
         var clientID: Int?
 
-        dialog.converse(dialogID: dialogID!, failure: failWithError) { response in
+        dialog.converse(usingDialogID: dialogID!, failure: failWithError) { response in
             XCTAssertEqual(response.response.last, response1)
             conversationID = response.conversationID
             clientID = response.clientID
@@ -469,8 +469,8 @@ class DialogTests: XCTestCase {
         let response2 = "What toppings are you in the mood for? (Limit 4)"
 
         dialog.converse(
-            dialogID: dialogID!,
-            conversationID: conversationID!,
+            usingDialogID: dialogID!,
+            withConversationID: conversationID!,
             clientID: clientID!,
             input: "large",
             failure: failWithError)
@@ -492,7 +492,7 @@ class DialogTests: XCTestCase {
         var conversationID: Int?
         var clientID: Int?
 
-        dialog.converse(dialogID: dialogID!, failure: failWithError) { response in
+        dialog.converse(usingDialogID: dialogID!, failure: failWithError) { response in
             conversationID = response.conversationID
             clientID = response.clientID
             expectation1.fulfill()
@@ -503,8 +503,8 @@ class DialogTests: XCTestCase {
         let expectation2 = self.expectation(description: description2)
 
         dialog.converse(
-            dialogID: dialogID!,
-            conversationID: conversationID!,
+            usingDialogID: dialogID!,
+            withConversationID: conversationID!,
             clientID: clientID!,
             input: "large",
             failure: failWithError)
@@ -517,7 +517,7 @@ class DialogTests: XCTestCase {
         let description3 = "Retrieve the client's profile variables."
         let expectation3 = self.expectation(description: description3)
 
-        dialog.getProfile(dialogID: dialogID!, clientID: clientID!, failure: failWithError) { profile in
+        dialog.getProfile(inDialogID: dialogID!, withClientID: clientID!, failure: failWithError) { profile in
             XCTAssertNil(profile.clientID)
             XCTAssertEqual(profile.parameters.first?.name, "size")
             XCTAssertEqual(profile.parameters.first?.value, "Large")
@@ -531,7 +531,7 @@ class DialogTests: XCTestCase {
         let description = "Update a new client's profile variables."
         let expectation = self.expectation(description: description)
 
-        dialog.updateProfile(dialogID: dialogID!, parameters: ["size": "Large"], failure: failWithError) {
+        dialog.updateProfile(inDialogID: dialogID!, parameters: ["size": "Large"], failure: failWithError) {
             expectation.fulfill()
         }
         waitForExpectations()
@@ -544,7 +544,7 @@ class DialogTests: XCTestCase {
 
         var clientID: Int?
 
-        dialog.converse(dialogID: dialogID!, failure: failWithError) { response in
+        dialog.converse(usingDialogID: dialogID!, failure: failWithError) { response in
             clientID = response.clientID
             expectation1.fulfill()
         }
@@ -554,8 +554,8 @@ class DialogTests: XCTestCase {
         let expectation2 = self.expectation(description: description2)
 
         dialog.updateProfile(
-            dialogID: dialogID!,
-            clientID: clientID!,
+            inDialogID: dialogID!,
+            withClientID: clientID!,
             parameters: ["size": "Large"],
             failure: failWithError)
         {
@@ -582,7 +582,7 @@ class DialogTests: XCTestCase {
             expectation.fulfill()
         }
 
-        dialog.createDialog(name: dialogName, fileURL: fileURL, failure: failure, success: failWithResult)
+        dialog.createDialog(withName: dialogName, fromFile: fileURL, failure: failure, success: failWithResult)
         waitForExpectations()
     }
 
@@ -600,7 +600,7 @@ class DialogTests: XCTestCase {
             expectation.fulfill()
         }
 
-        dialog.createDialog(name: dialogName!, fileURL: fileURL, failure: failure, success: failWithResult)
+        dialog.createDialog(withName: dialogName!, fromFile: fileURL, failure: failure, success: failWithResult)
         waitForExpectations()
     }
 
@@ -620,7 +620,7 @@ class DialogTests: XCTestCase {
             expectation.fulfill()
         }
 
-        dialog.createDialog(name: longName, fileURL: fileURL, failure: failure, success: failWithResult)
+        dialog.createDialog(withName: longName, fromFile: fileURL, failure: failure, success: failWithResult)
         waitForExpectations()
     }
 
@@ -637,7 +637,7 @@ class DialogTests: XCTestCase {
             expectation.fulfill()
         }
 
-        dialog.createDialog(name: dialogName, fileURL: fileURL, failure: failure, success: failWithResult)
+        dialog.createDialog(withName: dialogName, fromFile: fileURL, failure: failure, success: failWithResult)
         waitForExpectations()
     }
 
@@ -651,7 +651,7 @@ class DialogTests: XCTestCase {
             expectation.fulfill()
         }
 
-        dialog.deleteDialog(dialogID: invalidID, failure: failure, success: failWithResult)
+        dialog.deleteDialog(withID: invalidID, failure: failure, success: failWithResult)
         waitForExpectations()
     }
 
@@ -665,7 +665,7 @@ class DialogTests: XCTestCase {
             expectation.fulfill()
         }
 
-        dialog.getDialogFile(dialogID: invalidID, failure: failure, success: failWithResult)
+        dialog.getDialogFile(forDialogID: invalidID, failure: failure, success: failWithResult)
         waitForExpectations()
     }
 
@@ -683,7 +683,7 @@ class DialogTests: XCTestCase {
             expectation.fulfill()
         }
 
-        dialog.updateDialog(dialogID: dialogID!, fileURL: fileURL, failure: failure, success: failWithResult)
+        dialog.updateDialog(withID: dialogID!, fromFile: fileURL, failure: failure, success: failWithResult)
         waitForExpectations()
     }
 
@@ -698,7 +698,7 @@ class DialogTests: XCTestCase {
             expectation.fulfill()
         }
 
-        dialog.updateDialog(dialogID: dialogID!, fileURL: fileURL, failure: failure, success: failWithResult)
+        dialog.updateDialog(withID: dialogID!, fromFile: fileURL, failure: failure, success: failWithResult)
         waitForExpectations()
     }
 
@@ -718,7 +718,7 @@ class DialogTests: XCTestCase {
             expectation.fulfill()
         }
 
-        dialog.updateDialog(dialogID: invalidID, fileURL: fileURL, failure: failure, success: failWithResult)
+        dialog.updateDialog(withID: invalidID, fromFile: fileURL, failure: failure, success: failWithResult)
         waitForExpectations()
     }
 
@@ -733,7 +733,7 @@ class DialogTests: XCTestCase {
             expectation.fulfill()
         }
 
-        dialog.getContent(dialogID: invalidID, failure: failure, success: failWithResult)
+        dialog.getContent(ofDialogID: invalidID, failure: failure, success: failWithResult)
         waitForExpectations()
     }
 
@@ -748,7 +748,7 @@ class DialogTests: XCTestCase {
             expectation.fulfill()
         }
 
-        dialog.updateContent(dialogID: dialogID!, nodes: nodes, failure: failure, success: failWithResult)
+        dialog.updateContent(ofDialogID: dialogID!, forNodes: nodes, failure: failure, success: failWithResult)
         waitForExpectations()
     }
 
@@ -765,7 +765,7 @@ class DialogTests: XCTestCase {
             expectation.fulfill()
         }
 
-        dialog.updateContent(dialogID: invalidID, nodes: nodes, failure: failure, success: failWithResult)
+        dialog.updateContent(ofDialogID: invalidID, forNodes: nodes, failure: failure, success: failWithResult)
         waitForExpectations()
     }
 
@@ -791,9 +791,9 @@ class DialogTests: XCTestCase {
         }
 
         dialog.getConversationHistory(
-            dialogID: invalidID,
-            dateFrom: dateFrom,
-            dateTo: dateTo,
+            forDialogID: invalidID,
+            from: dateFrom,
+            to: dateTo,
             failure: failure,
             success: failWithResult
         )
@@ -811,7 +811,7 @@ class DialogTests: XCTestCase {
             expectation.fulfill()
         }
 
-        dialog.converse(dialogID: invalidID, failure: failure, success: failWithResult)
+        dialog.converse(usingDialogID: invalidID, failure: failure, success: failWithResult)
         waitForExpectations()
     }
 
@@ -828,8 +828,8 @@ class DialogTests: XCTestCase {
         }
 
         dialog.converse(
-            dialogID: dialogID!,
-            conversationID: invalidConversationID,
+            usingDialogID: dialogID!,
+            withConversationID: invalidConversationID,
             clientID: invalidClientID,
             input: "large",
             failure: failure,
@@ -853,8 +853,8 @@ class DialogTests: XCTestCase {
         }
 
         dialog.getProfile(
-            dialogID: invalidID,
-            clientID: invalidClientID,
+            inDialogID: invalidID,
+            withClientID: invalidClientID,
             failure: failure,
             success: failWithResult
         )
@@ -873,8 +873,8 @@ class DialogTests: XCTestCase {
         }
 
         dialog.getProfile(
-            dialogID: dialogID!,
-            clientID: invalidClientID,
+            inDialogID: dialogID!,
+            withClientID: invalidClientID,
             failure: failure,
             success: failWithResult
         )
@@ -888,7 +888,7 @@ class DialogTests: XCTestCase {
 
         var clientID: Int?
 
-        dialog.converse(dialogID: dialogID!, failure: failWithError) { response in
+        dialog.converse(usingDialogID: dialogID!, failure: failWithError) { response in
             clientID = response.clientID
             expectation1.fulfill()
         }
@@ -904,8 +904,8 @@ class DialogTests: XCTestCase {
         }
 
         dialog.getProfile(
-            dialogID: dialogID!,
-            clientID: clientID!,
+            inDialogID: dialogID!,
+            withClientID: clientID!,
             names: invalidParameters,
             failure: failure,
             success: failWithResult
@@ -925,7 +925,7 @@ class DialogTests: XCTestCase {
         }
 
         dialog.updateProfile(
-            dialogID: invalidID,
+            inDialogID: invalidID,
             parameters: ["size": "Large"],
             failure: failure,
             success: failWithResult
@@ -945,8 +945,8 @@ class DialogTests: XCTestCase {
         }
 
         dialog.updateProfile(
-            dialogID: dialogID!,
-            clientID: invalidID,
+            inDialogID: dialogID!,
+            withClientID: invalidID,
             parameters: ["size": "Large"],
             failure: failure,
             success: failWithResult

--- a/Source/DialogV1/Tests/DialogTests.swift
+++ b/Source/DialogV1/Tests/DialogTests.swift
@@ -194,7 +194,7 @@ class DialogTests: XCTestCase {
         let description = "Download the dialog file associated with the test application."
         let expectation = self.expectation(description: description)
         
-        dialog.getDialogFile(forDialogID: dialogID!, inFormat: format, failure: failWithError) { file in
+        dialog.getDialogFile(withDialogID: dialogID!, inFormat: format, failure: failWithError) { file in
             let fileManager = FileManager.default
             XCTAssertTrue(fileManager.fileExists(atPath: file.path))
             XCTAssertTrue(self.verifyFiletype(format: format, url: file))
@@ -262,7 +262,7 @@ class DialogTests: XCTestCase {
         let initialResponse = "Hi, I\'m Watson! I can help you order a pizza, " +
                               "what size would you like?"
 
-        dialog.getContent(ofDialogID: dialogID!, failure: failWithError) { nodes in
+        dialog.getContent(fromDialogID: dialogID!, failure: failWithError) { nodes in
             for node in nodes {
                 let nodeMatch = (node.node == initialNode)
                 let contentMatch = (node.content == initialResponse)
@@ -287,7 +287,7 @@ class DialogTests: XCTestCase {
 
         let newNode = DialogV1.Node(content: newGreeting, node: initialNode)
 
-        dialog.updateContent(ofDialogID: dialogID!, forNodes: [newNode], failure: failWithError) {
+        dialog.updateContent(fromDialogID: dialogID!, forNodes: [newNode], failure: failWithError) {
             expectation.fulfill()
         }
         waitForExpectations()
@@ -306,7 +306,7 @@ class DialogTests: XCTestCase {
         var conversationID: Int?
         var clientID: Int?
 
-        dialog.converse(usingDialogID: dialogID!, failure: failWithError) { response in
+        dialog.converse(withDialogID: dialogID!, failure: failWithError) { response in
             XCTAssertEqual(response.response.last, response1)
             conversationID = response.conversationID
             clientID = response.clientID
@@ -319,7 +319,7 @@ class DialogTests: XCTestCase {
 
         let response2 = "What toppings are you in the mood for? (Limit 4)"
 
-        dialog.converse(usingDialogID: dialogID!, withConversationID: conversationID!, clientID: clientID!, input: "large", failure: failWithError) {
+        dialog.converse(withDialogID: dialogID!, withConversationID: conversationID!, clientID: clientID!, input: "large", failure: failWithError) {
             response in
             XCTAssertEqual(response.response.last, response2)
             expectation2.fulfill()
@@ -336,7 +336,7 @@ class DialogTests: XCTestCase {
         let dateFrom = Date(timeInterval: serverOffset - bufferOffset, since: startTime)
         let dateTo = Date(timeIntervalSinceNow: serverOffset + bufferOffset)
 
-        dialog.getConversationHistory(forDialogID: dialogID!, from: dateFrom, to: dateTo, failure: failWithError) {
+        dialog.getConversationHistory(fromDialogID: dialogID!, from: dateFrom, to: dateTo, failure: failWithError) {
             conversations in
             XCTAssertGreaterThanOrEqual(conversations.count, 1)
             XCTAssertEqual(conversations.last?.messages.count, 3)
@@ -357,7 +357,7 @@ class DialogTests: XCTestCase {
         var conversationID: Int?
         var clientID: Int?
 
-        dialog.converse(usingDialogID: dialogID!, failure: failWithError) { response in
+        dialog.converse(withDialogID: dialogID!, failure: failWithError) { response in
             XCTAssertEqual(response.response.last, response1)
             conversationID = response.conversationID
             clientID = response.clientID
@@ -370,7 +370,7 @@ class DialogTests: XCTestCase {
 
         let response2 = "What toppings are you in the mood for? (Limit 4)"
 
-        dialog.converse(usingDialogID: dialogID!, withConversationID: conversationID!, clientID: clientID!, input: "large", failure: failWithError) {
+        dialog.converse(withDialogID: dialogID!, withConversationID: conversationID!, clientID: clientID!, input: "large", failure: failWithError) {
             response in
             XCTAssertEqual(response.response.last, response2)
             expectation2.fulfill()
@@ -388,7 +388,7 @@ class DialogTests: XCTestCase {
         let dateTo = Date(timeIntervalSinceNow: serverOffset + bufferOffset)
 
         let offset = 1000
-        dialog.getConversationHistory(forDialogID: dialogID!, from: dateFrom, to: dateTo, offset: offset, failure: failWithError) {
+        dialog.getConversationHistory(fromDialogID: dialogID!, from: dateFrom, to: dateTo, offset: offset, failure: failWithError) {
             conversations in
             XCTAssertEqual(conversations.count, 0)
             expectation3.fulfill()
@@ -406,7 +406,7 @@ class DialogTests: XCTestCase {
         var conversationID: Int?
         var clientID: Int?
 
-        dialog.converse(usingDialogID: dialogID!, failure: failWithError) { response in
+        dialog.converse(withDialogID: dialogID!, failure: failWithError) { response in
             XCTAssertEqual(response.response.last, response1)
             conversationID = response.conversationID
             clientID = response.clientID
@@ -419,7 +419,7 @@ class DialogTests: XCTestCase {
 
         let response2 = "What toppings are you in the mood for? (Limit 4)"
 
-        dialog.converse(usingDialogID: dialogID!, withConversationID: conversationID!, clientID: clientID!, input: "large", failure: failWithError) {
+        dialog.converse(withDialogID: dialogID!, withConversationID: conversationID!, clientID: clientID!, input: "large", failure: failWithError) {
             response in
             XCTAssertEqual(response.response.last, response2)
             expectation2.fulfill()
@@ -437,7 +437,7 @@ class DialogTests: XCTestCase {
         let dateTo = Date(timeIntervalSinceNow: serverOffset + bufferOffset)
 
         let limit = 0
-        dialog.getConversationHistory(forDialogID: dialogID!, from: dateFrom, to: dateTo, limit: limit, failure: failWithError) {
+        dialog.getConversationHistory(fromDialogID: dialogID!, from: dateFrom, to: dateTo, limit: limit, failure: failWithError) {
             conversations in
             // XCTAssertEqual(conversations.count, 0)
             expectation3.fulfill()
@@ -455,7 +455,7 @@ class DialogTests: XCTestCase {
         var conversationID: Int?
         var clientID: Int?
 
-        dialog.converse(usingDialogID: dialogID!, failure: failWithError) { response in
+        dialog.converse(withDialogID: dialogID!, failure: failWithError) { response in
             XCTAssertEqual(response.response.last, response1)
             conversationID = response.conversationID
             clientID = response.clientID
@@ -469,7 +469,7 @@ class DialogTests: XCTestCase {
         let response2 = "What toppings are you in the mood for? (Limit 4)"
 
         dialog.converse(
-            usingDialogID: dialogID!,
+            withDialogID: dialogID!,
             withConversationID: conversationID!,
             clientID: clientID!,
             input: "large",
@@ -492,7 +492,7 @@ class DialogTests: XCTestCase {
         var conversationID: Int?
         var clientID: Int?
 
-        dialog.converse(usingDialogID: dialogID!, failure: failWithError) { response in
+        dialog.converse(withDialogID: dialogID!, failure: failWithError) { response in
             conversationID = response.conversationID
             clientID = response.clientID
             expectation1.fulfill()
@@ -503,7 +503,7 @@ class DialogTests: XCTestCase {
         let expectation2 = self.expectation(description: description2)
 
         dialog.converse(
-            usingDialogID: dialogID!,
+            withDialogID: dialogID!,
             withConversationID: conversationID!,
             clientID: clientID!,
             input: "large",
@@ -517,7 +517,7 @@ class DialogTests: XCTestCase {
         let description3 = "Retrieve the client's profile variables."
         let expectation3 = self.expectation(description: description3)
 
-        dialog.getProfile(inDialogID: dialogID!, withClientID: clientID!, failure: failWithError) { profile in
+        dialog.getProfile(fromDialogID: dialogID!, withClientID: clientID!, failure: failWithError) { profile in
             XCTAssertNil(profile.clientID)
             XCTAssertEqual(profile.parameters.first?.name, "size")
             XCTAssertEqual(profile.parameters.first?.value, "Large")
@@ -531,7 +531,7 @@ class DialogTests: XCTestCase {
         let description = "Update a new client's profile variables."
         let expectation = self.expectation(description: description)
 
-        dialog.updateProfile(inDialogID: dialogID!, parameters: ["size": "Large"], failure: failWithError) {
+        dialog.updateProfile(fromDialogID: dialogID!, parameters: ["size": "Large"], failure: failWithError) {
             expectation.fulfill()
         }
         waitForExpectations()
@@ -544,7 +544,7 @@ class DialogTests: XCTestCase {
 
         var clientID: Int?
 
-        dialog.converse(usingDialogID: dialogID!, failure: failWithError) { response in
+        dialog.converse(withDialogID: dialogID!, failure: failWithError) { response in
             clientID = response.clientID
             expectation1.fulfill()
         }
@@ -554,7 +554,7 @@ class DialogTests: XCTestCase {
         let expectation2 = self.expectation(description: description2)
 
         dialog.updateProfile(
-            inDialogID: dialogID!,
+            fromDialogID: dialogID!,
             withClientID: clientID!,
             parameters: ["size": "Large"],
             failure: failWithError)
@@ -665,7 +665,7 @@ class DialogTests: XCTestCase {
             expectation.fulfill()
         }
 
-        dialog.getDialogFile(forDialogID: invalidID, failure: failure, success: failWithResult)
+        dialog.getDialogFile(withDialogID: invalidID, failure: failure, success: failWithResult)
         waitForExpectations()
     }
 
@@ -733,7 +733,7 @@ class DialogTests: XCTestCase {
             expectation.fulfill()
         }
 
-        dialog.getContent(ofDialogID: invalidID, failure: failure, success: failWithResult)
+        dialog.getContent(fromDialogID: invalidID, failure: failure, success: failWithResult)
         waitForExpectations()
     }
 
@@ -748,7 +748,7 @@ class DialogTests: XCTestCase {
             expectation.fulfill()
         }
 
-        dialog.updateContent(ofDialogID: dialogID!, forNodes: nodes, failure: failure, success: failWithResult)
+        dialog.updateContent(fromDialogID: dialogID!, forNodes: nodes, failure: failure, success: failWithResult)
         waitForExpectations()
     }
 
@@ -765,7 +765,7 @@ class DialogTests: XCTestCase {
             expectation.fulfill()
         }
 
-        dialog.updateContent(ofDialogID: invalidID, forNodes: nodes, failure: failure, success: failWithResult)
+        dialog.updateContent(fromDialogID: invalidID, forNodes: nodes, failure: failure, success: failWithResult)
         waitForExpectations()
     }
 
@@ -791,7 +791,7 @@ class DialogTests: XCTestCase {
         }
 
         dialog.getConversationHistory(
-            forDialogID: invalidID,
+            fromDialogID: invalidID,
             from: dateFrom,
             to: dateTo,
             failure: failure,
@@ -811,7 +811,7 @@ class DialogTests: XCTestCase {
             expectation.fulfill()
         }
 
-        dialog.converse(usingDialogID: invalidID, failure: failure, success: failWithResult)
+        dialog.converse(withDialogID: invalidID, failure: failure, success: failWithResult)
         waitForExpectations()
     }
 
@@ -828,7 +828,7 @@ class DialogTests: XCTestCase {
         }
 
         dialog.converse(
-            usingDialogID: dialogID!,
+            withDialogID: dialogID!,
             withConversationID: invalidConversationID,
             clientID: invalidClientID,
             input: "large",
@@ -853,7 +853,7 @@ class DialogTests: XCTestCase {
         }
 
         dialog.getProfile(
-            inDialogID: invalidID,
+            fromDialogID: invalidID,
             withClientID: invalidClientID,
             failure: failure,
             success: failWithResult
@@ -873,7 +873,7 @@ class DialogTests: XCTestCase {
         }
 
         dialog.getProfile(
-            inDialogID: dialogID!,
+            fromDialogID: dialogID!,
             withClientID: invalidClientID,
             failure: failure,
             success: failWithResult
@@ -888,7 +888,7 @@ class DialogTests: XCTestCase {
 
         var clientID: Int?
 
-        dialog.converse(usingDialogID: dialogID!, failure: failWithError) { response in
+        dialog.converse(withDialogID: dialogID!, failure: failWithError) { response in
             clientID = response.clientID
             expectation1.fulfill()
         }
@@ -904,7 +904,7 @@ class DialogTests: XCTestCase {
         }
 
         dialog.getProfile(
-            inDialogID: dialogID!,
+            fromDialogID: dialogID!,
             withClientID: clientID!,
             names: invalidParameters,
             failure: failure,
@@ -925,7 +925,7 @@ class DialogTests: XCTestCase {
         }
 
         dialog.updateProfile(
-            inDialogID: invalidID,
+            fromDialogID: invalidID,
             parameters: ["size": "Large"],
             failure: failure,
             success: failWithResult
@@ -945,7 +945,7 @@ class DialogTests: XCTestCase {
         }
 
         dialog.updateProfile(
-            inDialogID: dialogID!,
+            fromDialogID: dialogID!,
             withClientID: invalidID,
             parameters: ["size": "Large"],
             failure: failure,

--- a/Source/DialogV1/Tests/DialogTests.swift
+++ b/Source/DialogV1/Tests/DialogTests.swift
@@ -194,7 +194,7 @@ class DialogTests: XCTestCase {
         let description = "Download the dialog file associated with the test application."
         let expectation = self.expectation(description: description)
         
-        dialog.getDialogFile(withDialogID: dialogID!, inFormat: format, failure: failWithError) { file in
+        dialog.getDialogFile(fromDialogID: dialogID!, inFormat: format, failure: failWithError) { file in
             let fileManager = FileManager.default
             XCTAssertTrue(fileManager.fileExists(atPath: file.path))
             XCTAssertTrue(self.verifyFiletype(format: format, url: file))
@@ -665,7 +665,7 @@ class DialogTests: XCTestCase {
             expectation.fulfill()
         }
 
-        dialog.getDialogFile(withDialogID: invalidID, failure: failure, success: failWithResult)
+        dialog.getDialogFile(fromDialogID: invalidID, failure: failure, success: failWithResult)
         waitForExpectations()
     }
 


### PR DESCRIPTION
### Summary

Updated tests and renamed the enums as well