### PR TITLE
Updated Language Translator according to Swift 3.0 naming conventions

### DIFF
--- a/Source/LanguageTranslatorV2/LanguageTranslator.swift
+++ b/Source/LanguageTranslatorV2/LanguageTranslator.swift
@@ -134,8 +134,8 @@ public class LanguageTranslator {
      - parameter success: A function executed with the modelID of the created model.
      */
     public func createModel(
-        usingBaseModelID baseModelID: String,
-        fromFile forcedGlossary: URL,
+        fromBaseModelID baseModelID: String,
+        fromGlossaryFile forcedGlossary: URL,
         withName name: String? = nil,
         failure: ((Error) -> Void)? = nil,
         success: @escaping (String) -> Void)
@@ -265,7 +265,7 @@ public class LanguageTranslator {
      */
     public func translate(
         _ text: String,
-        usingModelID modelID: String,
+        withModelID modelID: String,
         failure: ((Error) -> Void)? = nil,
         success: @escaping (TranslateResponse) -> Void)
     {
@@ -285,7 +285,7 @@ public class LanguageTranslator {
      */
     public func translate(
         _ text: [String],
-        usingModelID modelID: String,
+        withModelID modelID: String,
         failure: ((Error) -> Void)? = nil,
         success: @escaping (TranslateResponse) -> Void)
     {

--- a/Source/LanguageTranslatorV2/LanguageTranslator.swift
+++ b/Source/LanguageTranslatorV2/LanguageTranslator.swift
@@ -70,27 +70,27 @@ public class LanguageTranslator {
     /**
      List the available standard and custom models.
      
-     - parameter source: Specify a source to filter models by source language.
-     - parameter target: Specify a target to filter models by target language.
+     - parameter sourceLanguage: Filter models by a source language.
+     - parameter targetLanguage: Filter models by a target language.
      - parameter defaultModelsOnly: Specify `true` to filter models by whether they are default.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the list of available standard and custom models.
      */
     public func getModels(
-        withSourceLanguage source: String? = nil,
-        withTargetLanguage target: String? = nil,
+        sourceLanguage: String? = nil,
+        targetLanguage: String? = nil,
         defaultModelsOnly: Bool? = nil,
         failure: ((Error) -> Void)? = nil,
         success: @escaping ([TranslationModel]) -> Void)
     {
         // construct query parameters
         var queryParameters = [URLQueryItem]()
-        if let source = source {
-            let queryParameter = URLQueryItem(name: "source", value: source)
+        if let sourceLanguage = sourceLanguage {
+            let queryParameter = URLQueryItem(name: "source", value: sourceLanguage)
             queryParameters.append(queryParameter)
         }
-        if let target = target {
-            let queryParameter = URLQueryItem(name: "target", value: target)
+        if let targetLanguage = targetLanguage {
+            let queryParameter = URLQueryItem(name: "target", value: targetLanguage)
             queryParameters.append(queryParameter)
         }
         if let defaultModelsOnly = defaultModelsOnly {
@@ -125,8 +125,8 @@ public class LanguageTranslator {
      hours for a large parallel corpus. Glossary files must be less than 10 MB. The cumulative file
      size of all uploaded glossary and corpus files is limited to 250 MB.
      
-     - parameter baseModelID: Specifies the domain model that is used as the base for the training.
-     - parameter forcedGlossary: A TMX file with your customizations. Anything that is specified in
+     - parameter fromBaseModelID: Specifies the domain model that is used as the base for the training.
+     - parameter withGlossary: A TMX file with your customizations. Anything that is specified in
             this file completely overwrites the domain data translation. You can upload only one
      - parameter name: The model name. Valid characters are letters, numbers, -, and _. No spaces.
             glossary with a file size less than 10 MB per call.
@@ -135,8 +135,8 @@ public class LanguageTranslator {
      */
     public func createModel(
         fromBaseModelID baseModelID: String,
-        fromGlossaryFile forcedGlossary: URL,
-        withName name: String? = nil,
+        withGlossary forcedGlossary: URL,
+        name: String? = nil,
         failure: ((Error) -> Void)? = nil,
         success: @escaping (String) -> Void)
     {
@@ -187,7 +187,7 @@ public class LanguageTranslator {
     /**
      Delete a trained translation model.
      
-     - parameter modelID: The translation model's identifier.
+     - parameter withID: The translation model's identifier.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed after the given model has been deleted.
      */
@@ -223,7 +223,7 @@ public class LanguageTranslator {
     /**
      Get information about the given translation model, including training status.
      
-     - parameter modelID: The translation model's identifier.
+     - parameter withID: The translation model's identifier.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the retrieved information about the model.
      */
@@ -257,8 +257,8 @@ public class LanguageTranslator {
      Translate text from a source language to a target language.
      
      - parameter text: The text to translate.
-     - parameter modelID: The unique modelID of the translation model that shall be used to
-            translate the text. The modelID inherently specifies the source, target language, and
+     - parameter withModelID: The unique model id of the translation model that shall be used to
+            translate the text. The model id inherently specifies the source, target language, and
             domain.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the translation.
@@ -277,8 +277,8 @@ public class LanguageTranslator {
      Translate text from a source language to a target language.
      
      - parameter text: The text to translate.
-     - parameter modelID: The unique modelID of the translation model that shall be used to
-            translate the text. The modelID inherently specifies the source, target language, and
+     - parameter withModelID: The unique model id of the translation model that shall be used to
+            translate the text. The model id inherently specifies the source, target language, and
             domain.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the translation.
@@ -297,21 +297,21 @@ public class LanguageTranslator {
      Translate text from a source language to a target language.
      
      - parameter text: The text to translate.
-     - parameter source:  The source language in 2 or 5 letter language code. Use 2 letter codes
+     - parameter from: The source language in 2 or 5 letter language code. Use 2 letter codes
             except when clarifying between multiple supported languages.
-     - parameter target: The target language in 2 or 5 letter language code. Use 2 letter codes
+     - parameter to: The target language in 2 or 5 letter language code. Use 2 letter codes
             except when clarifying between multiple supported languages.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the translation.
      */
     public func translate(
         _ text: String,
-        fromLanguage source: String,
-        toLanguage target: String,
+        from sourceLanguage: String,
+        to targetLanguage: String,
         failure: ((Error) -> Void)? = nil,
         success: @escaping (TranslateResponse) -> Void)
     {
-        let translateRequest = TranslateRequest(text: [text], source: source, target: target)
+        let translateRequest = TranslateRequest(text: [text], source: sourceLanguage, target: targetLanguage)
         translate(translateRequest: translateRequest, failure: failure, success: success)
     }
 
@@ -319,21 +319,21 @@ public class LanguageTranslator {
      Translate text from a source language to a target language.
      
      - parameter text: The text to translate.
-     - parameter source:  The source language in 2 or 5 letter language code. Use 2 letter codes
+     - parameter from: The source language in 2 or 5 letter language code. Use 2 letter codes
             except when clarifying between multiple supported languages.
-     - parameter target: The target language in 2 or 5 letter language code. Use 2 letter codes
+     - parameter to: The target language in 2 or 5 letter language code. Use 2 letter codes
             except when clarifying between multiple supported languages.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the translation.
      */
     public func translate(
         _ text: [String],
-        fromLanguage source: String,
-        toLanguage target: String,
+        from sourceLanguage: String,
+        to targetLanguage: String,
         failure: ((Error) -> Void)? = nil,
         success: @escaping (TranslateResponse) -> Void)
     {
-        let translateRequest = TranslateRequest(text: text, source: source, target: target)
+        let translateRequest = TranslateRequest(text: text, source: sourceLanguage, target: targetLanguage)
         translate(translateRequest: translateRequest, failure: failure, success: success)
     }
 
@@ -414,7 +414,7 @@ public class LanguageTranslator {
     /**
      Identify the language of the given text.
      
-     - parameter text: The text whose language shall be identified.
+     - parameter languageOf: The text whose language shall be identified.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with all identified languages in the given text.
      */

--- a/Source/LanguageTranslatorV2/LanguageTranslator.swift
+++ b/Source/LanguageTranslatorV2/LanguageTranslator.swift
@@ -77,8 +77,8 @@ public class LanguageTranslator {
      - parameter success: A function executed with the list of available standard and custom models.
      */
     public func getModels(
-        source: String? = nil,
-        target: String? = nil,
+        withSourceLanguage source: String? = nil,
+        withTargetLanguage target: String? = nil,
         defaultModelsOnly: Bool? = nil,
         failure: ((Error) -> Void)? = nil,
         success: @escaping ([TranslationModel]) -> Void)
@@ -134,9 +134,9 @@ public class LanguageTranslator {
      - parameter success: A function executed with the modelID of the created model.
      */
     public func createModel(
-        baseModelID: String,
-        name: String? = nil,
-        forcedGlossary: URL,
+        usingBaseModelID baseModelID: String,
+        withName name: String? = nil,
+        fromFile forcedGlossary: URL,
         failure: ((Error) -> Void)? = nil,
         success: @escaping (String) -> Void)
     {
@@ -192,7 +192,7 @@ public class LanguageTranslator {
      - parameter success: A function executed after the given model has been deleted.
      */
     public func deleteModel(
-        modelID: String,
+        withID modelID: String,
         failure: ((Error) -> Void)? = nil,
         success: ((Void) -> Void)? = nil)
     {
@@ -228,7 +228,7 @@ public class LanguageTranslator {
      - parameter success: A function executed with the retrieved information about the model.
      */
     public func getModel(
-        modelID: String,
+        withID modelID: String,
         failure: ((Error) -> Void)? = nil,
         success: @escaping (MonitorTraining) -> Void)
     {
@@ -264,8 +264,8 @@ public class LanguageTranslator {
      - parameter success: A function executed with the translation.
      */
     public func translate(
-        text: String,
-        modelID: String,
+        _ text: String,
+        usingModelID modelID: String,
         failure: ((Error) -> Void)? = nil,
         success: @escaping (TranslateResponse) -> Void)
     {
@@ -284,8 +284,8 @@ public class LanguageTranslator {
      - parameter success: A function executed with the translation.
      */
     public func translate(
-        text: [String],
-        modelID: String,
+        _ text: [String],
+        usingModelID modelID: String,
         failure: ((Error) -> Void)? = nil,
         success: @escaping (TranslateResponse) -> Void)
     {
@@ -305,9 +305,9 @@ public class LanguageTranslator {
      - parameter success: A function executed with the translation.
      */
     public func translate(
-        text: String,
-        source: String,
-        target: String,
+        _ text: String,
+        fromLanguage source: String,
+        toLanguage target: String,
         failure: ((Error) -> Void)? = nil,
         success: @escaping (TranslateResponse) -> Void)
     {
@@ -327,9 +327,9 @@ public class LanguageTranslator {
      - parameter success: A function executed with the translation.
      */
     public func translate(
-        text: [String],
-        source: String,
-        target: String,
+        _ text: [String],
+        fromLanguage source: String,
+        toLanguage target: String,
         failure: ((Error) -> Void)? = nil,
         success: @escaping (TranslateResponse) -> Void)
     {
@@ -419,7 +419,7 @@ public class LanguageTranslator {
      - parameter success: A function executed with all identified languages in the given text.
      */
     public func identify(
-        text: String,
+        languageOf text: String,
         failure: ((Error) -> Void)? = nil,
         success: @escaping ([IdentifiedLanguage]) -> Void)
     {

--- a/Source/LanguageTranslatorV2/LanguageTranslator.swift
+++ b/Source/LanguageTranslatorV2/LanguageTranslator.swift
@@ -126,17 +126,17 @@ public class LanguageTranslator {
      size of all uploaded glossary and corpus files is limited to 250 MB.
      
      - parameter baseModelID: Specifies the domain model that is used as the base for the training.
-     - parameter name: The model name. Valid characters are letters, numbers, -, and _. No spaces.
      - parameter forcedGlossary: A TMX file with your customizations. Anything that is specified in
             this file completely overwrites the domain data translation. You can upload only one
+     - parameter name: The model name. Valid characters are letters, numbers, -, and _. No spaces.
             glossary with a file size less than 10 MB per call.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the modelID of the created model.
      */
     public func createModel(
         usingBaseModelID baseModelID: String,
-        withName name: String? = nil,
         fromFile forcedGlossary: URL,
+        withName name: String? = nil,
         failure: ((Error) -> Void)? = nil,
         success: @escaping (String) -> Void)
     {

--- a/Source/LanguageTranslatorV2/Tests/LanguageTranslatorTests.swift
+++ b/Source/LanguageTranslatorV2/Tests/LanguageTranslatorTests.swift
@@ -134,7 +134,7 @@ class LanguageTranslatorTests: XCTestCase {
             return
         }
         
-        languageTranslator.createModel(usingBaseModelID: "en-es", fromFile: glossary,
+        languageTranslator.createModel(fromBaseModelID: "en-es", fromGlossaryFile: glossary,
             withName: "custom-english-to-spanish-model", failure: failWithError)
         {
             modelID in
@@ -167,7 +167,7 @@ class LanguageTranslatorTests: XCTestCase {
 
         let text = "Hello"
         let modelID = "en-es-conversational"
-        languageTranslator.translate(text, usingModelID: modelID, failure: failWithError) {
+        languageTranslator.translate(text, withModelID: modelID, failure: failWithError) {
             translation in
             XCTAssertEqual(translation.wordCount, 1)
             XCTAssertEqual(translation.characterCount, 5)
@@ -185,7 +185,7 @@ class LanguageTranslatorTests: XCTestCase {
 
         let text = ["Hello"]
         let modelID = "en-es-conversational"
-        languageTranslator.translate(text, usingModelID: modelID, failure: failWithError) {
+        languageTranslator.translate(text, withModelID: modelID, failure: failWithError) {
             translation in
             XCTAssertEqual(translation.wordCount, 1)
             XCTAssertEqual(translation.characterCount, 5)

--- a/Source/LanguageTranslatorV2/Tests/LanguageTranslatorTests.swift
+++ b/Source/LanguageTranslatorV2/Tests/LanguageTranslatorTests.swift
@@ -46,7 +46,7 @@ class LanguageTranslatorTests: XCTestCase {
         languageTranslator.getModels(defaultModelsOnly: false, failure: failWithError) { models in
             for model in models {
                 if model.baseModelID != "" {
-                    self.languageTranslator.deleteModel(modelID: model.modelID)
+                    self.languageTranslator.deleteModel(withID: model.modelID)
                 }
             }
             expectation.fulfill()
@@ -90,7 +90,7 @@ class LanguageTranslatorTests: XCTestCase {
         let description = "Get models, filtered by source language."
         let expectation = self.expectation(description: description)
 
-        languageTranslator.getModels(source: "es", failure: failWithError) { models in
+        languageTranslator.getModels(withSourceLanguage: "es", failure: failWithError) { models in
             XCTAssertGreaterThan(models.count, 0, "Expected at least 1 model to be returned.")
             expectation.fulfill()
         }
@@ -102,7 +102,7 @@ class LanguageTranslatorTests: XCTestCase {
         let description = "Get models, filtered by target language."
         let expectation = self.expectation(description: description)
 
-        languageTranslator.getModels(target: "pt", failure: failWithError) { models in
+        languageTranslator.getModels(withTargetLanguage: "pt", failure: failWithError) { models in
             XCTAssertGreaterThan(models.count, 0, "Expected at least 1 model to be returned.")
             expectation.fulfill()
         }
@@ -133,15 +133,15 @@ class LanguageTranslatorTests: XCTestCase {
             XCTFail("Unable to read forced glossary.")
             return
         }
-
-        languageTranslator.createModel(baseModelID: "en-es", name: "custom-english-to-spanish-model",
-            forcedGlossary: glossary, failure: failWithError)
+        
+        languageTranslator.createModel(usingBaseModelID: "en-es", fromFile: glossary,
+            withName: "custom-english-to-spanish-model", failure: failWithError)
         {
             modelID in
             XCTAssertNotEqual(modelID, "")
             creationExpectation.fulfill()
 
-            self.languageTranslator.deleteModel(modelID: modelID, failure: self.failWithError) {
+            self.languageTranslator.deleteModel(withID: modelID, failure: self.failWithError) {
                 deletionExpectation.fulfill()
             }
         }
@@ -153,7 +153,7 @@ class LanguageTranslatorTests: XCTestCase {
         let description = "Get a model's training status."
         let expectation = self.expectation(description: description)
 
-        languageTranslator.getModel(modelID: "en-es", failure: failWithError) { monitorTraining in
+        languageTranslator.getModel(withID: "en-es", failure: failWithError) { monitorTraining in
             XCTAssertEqual(monitorTraining.status, TrainingStatus.available)
             expectation.fulfill()
         }
@@ -167,7 +167,7 @@ class LanguageTranslatorTests: XCTestCase {
 
         let text = "Hello"
         let modelID = "en-es-conversational"
-        languageTranslator.translate(text: text, modelID: modelID, failure: failWithError) {
+        languageTranslator.translate(text, usingModelID: modelID, failure: failWithError) {
             translation in
             XCTAssertEqual(translation.wordCount, 1)
             XCTAssertEqual(translation.characterCount, 5)
@@ -185,7 +185,7 @@ class LanguageTranslatorTests: XCTestCase {
 
         let text = ["Hello"]
         let modelID = "en-es-conversational"
-        languageTranslator.translate(text: text, modelID: modelID, failure: failWithError) {
+        languageTranslator.translate(text, usingModelID: modelID, failure: failWithError) {
             translation in
             XCTAssertEqual(translation.wordCount, 1)
             XCTAssertEqual(translation.characterCount, 5)
@@ -201,7 +201,7 @@ class LanguageTranslatorTests: XCTestCase {
         let description = "Translate text string, specifying the model by source and target."
         let expectation = self.expectation(description: description)
 
-        languageTranslator.translate(text: "Hello", source: "en", target: "es", failure: failWithError) {
+        languageTranslator.translate("Hello", fromLanguage: "en", toLanguage: "es", failure: failWithError) {
             translation in
             XCTAssertEqual(translation.wordCount, 1)
             XCTAssertEqual(translation.characterCount, 5)
@@ -217,7 +217,7 @@ class LanguageTranslatorTests: XCTestCase {
         let description = "Translate text array, specifying the model by source and target."
         let expectation = self.expectation(description: description)
 
-        languageTranslator.translate(text: ["Hello"], source: "en", target: "es", failure: failWithError) {
+        languageTranslator.translate(["Hello"], fromLanguage: "en", toLanguage: "es", failure: failWithError) {
             translation in
             XCTAssertEqual(translation.wordCount, 1)
             XCTAssertEqual(translation.characterCount, 5)
@@ -245,7 +245,7 @@ class LanguageTranslatorTests: XCTestCase {
         let description = "Identify the language of a text string."
         let expectation = self.expectation(description: description)
 
-        languageTranslator.identify(text: "Hola", failure: failWithError) { languages in
+        languageTranslator.identify(languageOf: "Hola", failure: failWithError) { languages in
             XCTAssertGreaterThan(languages.count, 0, "Expected at least 1 language to be returned.")
             XCTAssertEqual(languages.first?.language, "es")
             XCTAssertGreaterThanOrEqual(languages.first!.confidence, 0.0)
@@ -266,7 +266,7 @@ class LanguageTranslatorTests: XCTestCase {
             expectation.fulfill()
         }
 
-        languageTranslator.getModel(modelID: "invalid_model_id", failure: failure, success: failWithResult)
+        languageTranslator.getModel(withID: "invalid_model_id", failure: failure, success: failWithResult)
         waitForExpectations()
     }
 }

--- a/Source/LanguageTranslatorV2/Tests/LanguageTranslatorTests.swift
+++ b/Source/LanguageTranslatorV2/Tests/LanguageTranslatorTests.swift
@@ -90,7 +90,7 @@ class LanguageTranslatorTests: XCTestCase {
         let description = "Get models, filtered by source language."
         let expectation = self.expectation(description: description)
 
-        languageTranslator.getModels(withSourceLanguage: "es", failure: failWithError) { models in
+        languageTranslator.getModels(sourceLanguage: "es", failure: failWithError) { models in
             XCTAssertGreaterThan(models.count, 0, "Expected at least 1 model to be returned.")
             expectation.fulfill()
         }
@@ -102,7 +102,7 @@ class LanguageTranslatorTests: XCTestCase {
         let description = "Get models, filtered by target language."
         let expectation = self.expectation(description: description)
 
-        languageTranslator.getModels(withTargetLanguage: "pt", failure: failWithError) { models in
+        languageTranslator.getModels(targetLanguage: "pt", failure: failWithError) { models in
             XCTAssertGreaterThan(models.count, 0, "Expected at least 1 model to be returned.")
             expectation.fulfill()
         }
@@ -134,8 +134,8 @@ class LanguageTranslatorTests: XCTestCase {
             return
         }
         
-        languageTranslator.createModel(fromBaseModelID: "en-es", fromGlossaryFile: glossary,
-            withName: "custom-english-to-spanish-model", failure: failWithError)
+        languageTranslator.createModel(fromBaseModelID: "en-es", withGlossary: glossary,
+                                       name: "custom-english-to-spanish-model", failure: failWithError)
         {
             modelID in
             XCTAssertNotEqual(modelID, "")
@@ -201,7 +201,7 @@ class LanguageTranslatorTests: XCTestCase {
         let description = "Translate text string, specifying the model by source and target."
         let expectation = self.expectation(description: description)
 
-        languageTranslator.translate("Hello", fromLanguage: "en", toLanguage: "es", failure: failWithError) {
+        languageTranslator.translate("Hello", from: "en", to: "es", failure: failWithError) {
             translation in
             XCTAssertEqual(translation.wordCount, 1)
             XCTAssertEqual(translation.characterCount, 5)
@@ -217,7 +217,7 @@ class LanguageTranslatorTests: XCTestCase {
         let description = "Translate text array, specifying the model by source and target."
         let expectation = self.expectation(description: description)
 
-        languageTranslator.translate(["Hello"], fromLanguage: "en", toLanguage: "es", failure: failWithError) {
+        languageTranslator.translate(["Hello"], from: "en", to: "es", failure: failWithError) {
             translation in
             XCTAssertEqual(translation.wordCount, 1)
             XCTAssertEqual(translation.characterCount, 5)


### PR DESCRIPTION
### Summary

Changed a few parameter names for methods and updated tests.