### PR TITLE
Fix broken links

### DIFF
--- a/Source/SpeechToTextV1/Models/RecognitionSettings.swift
+++ b/Source/SpeechToTextV1/Models/RecognitionSettings.swift
@@ -21,8 +21,8 @@ import RestKit
  The settings associated with a Speech to Text recognition request. Any `nil` parameters will
  use a default value provided by the Watson Speech to Text service.
  
- Visit https://ibm.biz/BdHCrX for more information about the Speech to Text service's
- parameters.
+ For more information about the Speech to Text service parameters, visit:
+ http://www.ibm.com/watson/developercloud/doc/speech-to-text/input.shtml
  */
 public struct RecognitionSettings: JSONEncodable {
 
@@ -30,7 +30,8 @@ public struct RecognitionSettings: JSONEncodable {
     private let action = "start"
 
     /// The format of the audio data. Endianness is automatically detected by the Speech to Text
-    /// service. Visit https://ibm.biz/BdHCrB for more information about the supported formats.
+    /// service. For more information aboutthe supported formats, visit:
+    /// http://www.ibm.com/watson/developercloud/doc/speech-to-text/input.shtml#formats
     public var contentType: AudioMediaType
 
     /// If `true`, then the entire audio stream will be transcribed until it terminates rather
@@ -82,8 +83,8 @@ public struct RecognitionSettings: JSONEncodable {
      Text recognition request.
 
      - parameter contentType: The format of the audio data. Endianness is automatically detected
-        by the Speech to Text service. Visit https://ibm.biz/BdHCrB for more information about
-        the supported formats.
+        by the Speech to Text service. For more information about the supported formats, visit:
+        http://www.ibm.com/watson/developercloud/doc/speech-to-text/input.shtml#formats
      
      - returns: An initialized `RecognitionSettings` object with the given `contentType`.
         Configure additional parameters for the recognition request by directly modifying


### PR DESCRIPTION
The `ibm.biz` short URLs were broken. This caused broken links in the generated documentation. This pull request fixes the broken links and avoids using shortened URLs (which can make find-and-replace-all difficult).