### PR TITLE
Add guard let to avoid coercing from Any? to Any

### DIFF
--- a/Source/RestKit/JSON.swift
+++ b/Source/RestKit/JSON.swift
@@ -25,7 +25,9 @@ public protocol JSONPathType {
 
 extension String: JSONPathType {
     public func value(in dictionary: [String: Any]) throws -> JSON {
-        let json = dictionary[self]
+        guard let json = dictionary[self] else {
+            throw JSON.Error.keyNotFound(key: self)
+        }
         return JSON(json: json)
     }
     


### PR DESCRIPTION
I think this change will remove the warning messages that appear when building the SDK with Carthage or the Swift Package Manager:

```
/Users/glennfisher/Desktop/Text to Speech/Carthage/Checkouts/ios-sdk/Source/RestKit/JSON.swift:29:27: warning: expression implicitly coerced from 'Any?' to Any
```