### PR TITLE
Fix Linux errors

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -40,5 +40,6 @@ let package = Package(
     ],
     exclude: [
         "Source/SpeechToTextV1",
+        "Tests/SpeechToTextV1"
     ]
 )

--- a/Source/DocumentConversionV1/DocumentConversion.swift
+++ b/Source/DocumentConversionV1/DocumentConversion.swift
@@ -160,14 +160,14 @@ public class DocumentConversion {
         
         // create a globally unique file name in a temporary directory
         let suffix = "DocumentConversionConfiguration.json"
-        let fileName = String(format: "%@_%@", UUID().uuidString, suffix)
+        let fileName = "\(UUID().uuidString)_\(suffix)"
         let directoryURL = NSURL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
         let fileURL = directoryURL.appendingPathComponent(fileName)!
         
         // save JSON dictionary to file
         do {
             let data = try JSON(dictionary: json).serialize()
-            try data.write(to: fileURL, options: .atomicWrite)
+            try data.write(to: fileURL, options: .atomic)
         } catch {
             let message = "Unable to create config file"
             let userInfo = [NSLocalizedFailureReasonErrorKey: message]

--- a/Tests/AlchemyDataNewsV1Tests/AlchemyDataNewsTests.swift
+++ b/Tests/AlchemyDataNewsV1Tests/AlchemyDataNewsTests.swift
@@ -14,8 +14,8 @@
  * limitations under the License.
  **/
 import XCTest
-import AlchemyDataNewsV1
 import Foundation
+import AlchemyDataNewsV1
 
 class AlchemyDataNewsTests: XCTestCase {
     

--- a/Tests/AlchemyLanguageV1Tests/AlchemyLanguageTests.swift
+++ b/Tests/AlchemyLanguageV1Tests/AlchemyLanguageTests.swift
@@ -15,6 +15,7 @@
  **/
 
 import XCTest
+import Foundation
 import AlchemyLanguageV1
 
 class AlchemyLanguageTests: XCTestCase {

--- a/Tests/AlchemyVisionV1Tests/AlchemyVisionTests.swift
+++ b/Tests/AlchemyVisionV1Tests/AlchemyVisionTests.swift
@@ -15,6 +15,7 @@
  **/
 
 import XCTest
+import Foundation
 import AlchemyVisionV1
 
 class AlchemyVisionTests: XCTestCase {

--- a/Tests/ConversationV1Tests/ConversationTests.swift
+++ b/Tests/ConversationV1Tests/ConversationTests.swift
@@ -15,6 +15,7 @@
  **/
 
 import XCTest
+import Foundation
 import ConversationV1
 
 class ConversationTests: XCTestCase {

--- a/Tests/DialogV1Tests/DialogTests.swift
+++ b/Tests/DialogV1Tests/DialogTests.swift
@@ -15,6 +15,7 @@
  **/
 
 import XCTest
+import Foundation
 import DialogV1
 
 class DialogTests: XCTestCase {

--- a/Tests/DocumentConversionV1Tests/DocumentConversionTests.swift
+++ b/Tests/DocumentConversionV1Tests/DocumentConversionTests.swift
@@ -15,6 +15,7 @@
  **/
 
 import XCTest
+import Foundation
 import DocumentConversionV1
 
 class DocumentConversionTests: XCTestCase {

--- a/Tests/LanguageTranslatorV2Tests/LanguageTranslatorTests.swift
+++ b/Tests/LanguageTranslatorV2Tests/LanguageTranslatorTests.swift
@@ -15,6 +15,7 @@
  **/
 
 import XCTest
+import Foundation
 import LanguageTranslatorV2
 
 class LanguageTranslatorTests: XCTestCase {

--- a/Tests/NaturalLanguageClassifierV1Tests/NaturalLanguageClassifierTests.swift
+++ b/Tests/NaturalLanguageClassifierV1Tests/NaturalLanguageClassifierTests.swift
@@ -15,6 +15,7 @@
  **/
 
 import XCTest
+import Foundation
 import NaturalLanguageClassifierV1
 
 class NaturalLanguageClassifierTests: XCTestCase {

--- a/Tests/PersonalityInsightsV2Tests/PersonalityInsightsTests.swift
+++ b/Tests/PersonalityInsightsV2Tests/PersonalityInsightsTests.swift
@@ -15,6 +15,7 @@
  **/
 
 import XCTest
+import Foundation
 import PersonalityInsightsV2
 
 class PersonalityInsightsTests: XCTestCase {

--- a/Tests/RelationshipExtractionV1BetaTests/RelationshipExtractionTests.swift
+++ b/Tests/RelationshipExtractionV1BetaTests/RelationshipExtractionTests.swift
@@ -15,6 +15,7 @@
  **/
 
 import XCTest
+import Foundation
 import RelationshipExtractionV1Beta
 
 class RelationshipExtractionTests: XCTestCase {

--- a/Tests/RetrieveAndRankV1Tests/RetrieveAndRankTests.swift
+++ b/Tests/RetrieveAndRankV1Tests/RetrieveAndRankTests.swift
@@ -15,6 +15,7 @@
  **/
 
 import XCTest
+import Foundation
 import RetrieveAndRankV1
 
 class RetrieveAndRankTests: XCTestCase {

--- a/Tests/SpeechToTextV1Tests/SpeechToTextTests.swift
+++ b/Tests/SpeechToTextV1Tests/SpeechToTextTests.swift
@@ -15,6 +15,7 @@
  **/
 
 import XCTest
+import Foundation
 import SpeechToTextV1
 
 class SpeechToTextTests: XCTestCase {

--- a/Tests/TextToSpeechV1Tests/TextToSpeechTests.swift
+++ b/Tests/TextToSpeechV1Tests/TextToSpeechTests.swift
@@ -15,8 +15,8 @@
  **/
 
 import XCTest
-import TextToSpeechV1
 import Foundation
+import TextToSpeechV1
 
 class TextToSpeechTests: XCTestCase {
     

--- a/Tests/ToneAnalyzerV3Tests/ToneAnalyzerTests.swift
+++ b/Tests/ToneAnalyzerV3Tests/ToneAnalyzerTests.swift
@@ -15,6 +15,7 @@
  **/
 
 import XCTest
+import Foundation
 import ToneAnalyzerV3
 
 class ToneAnalyzerTests: XCTestCase {

--- a/Tests/TradeoffAnalyticsV1Tests/TradeoffAnalyticsTests.swift
+++ b/Tests/TradeoffAnalyticsV1Tests/TradeoffAnalyticsTests.swift
@@ -15,6 +15,7 @@
  **/
 
 import XCTest
+import Foundation
 import TradeoffAnalyticsV1
 
 class TradeoffAnalyticsTests: XCTestCase {

--- a/Tests/VisualRecognitionV3Tests/VisualRecognitionTests.swift
+++ b/Tests/VisualRecognitionV3Tests/VisualRecognitionTests.swift
@@ -15,6 +15,7 @@
  **/
 
 import XCTest
+import Foundation
 import VisualRecognitionV3
 
 class VisualRecognitionTests: XCTestCase {


### PR DESCRIPTION
### Summary

Ignoring the STT tests, and added in a fix for the Document Conversion errors. Also included Foundation in all the test files.

There's still one more error in Dialog at [this line](https://github.com/watson-developer-cloud/ios-sdk/blob/fix-linux-errors/Tests/DialogV1Tests/DialogTests.swift#L164). Specifically,
```let randomNum = Int(arc4random_uniform(allowedCharsCount))```