### PR TITLE
Ensure data payload is not empty

### DIFF
--- a/Source/SpeechToTextV1/SpeechToTextSession.swift
+++ b/Source/SpeechToTextV1/SpeechToTextSession.swift
@@ -242,6 +242,7 @@ public class SpeechToTextSession {
                 guard pcm.count > 0 else { return }
                 try! self.encoder.encode(pcm: pcm)
                 let opus = self.encoder.bitstream(flush: true)
+                guard opus.count > 0 else { return }
                 self.socket.writeAudio(audio: opus)
                 self.onMicrophoneData?(opus)
             }
@@ -282,6 +283,7 @@ public class SpeechToTextSession {
         
         if compress {
             let opus = try! encoder.endstream()
+            guard opus.count > 0 else { return }
             self.socket.writeAudio(audio: opus)
         }
     }


### PR DESCRIPTION
We have occasionally seen an error message related to insufficient data in the audio stream. We suspect it is caused by writing zero bytes to the websocket, which is interpreted by the service as the end of the stream. This commit guards against sending 0 bytes when streaming from the microphone.

Note that users can still use the SpeechToTextSession class and accidentally send a 0-byte Data value. In that case, we want the error to propagate back to the user, which is why we didn’t add these guard statements to the SpeechToTextSocket.writeAudio(audio:) function.