### PR TITLE
Upload images with Visual Recognition

### DIFF
--- a/Source/VisualRecognitionV3/VisualRecognition.swift
+++ b/Source/VisualRecognitionV3/VisualRecognition.swift
@@ -148,92 +148,87 @@ public class VisualRecognition {
         }
     }
     
-    // TODO: The following classify function uploads images to be classified.
-    // Unfortunately, we are seeing an undefined error from the service.
-    // Most likely, there is an issue with the multipart/form data payload.
-    // We will be investigating this issue further and issuing updates soon.
-    
-//    /**
-//     Upload and classify an image or multiple images in a compressed (.zip) file.
-//     
-//     - parameter imageFile: The image file (.jpg or .png) or compressed (.zip) file of images. The
-//        total number of images is limited to 20, with a max .zip size of 5 MB.
-//     - parameter owners: A list of the classifiers to run. Acceptable values are "IBM" and "me".
-//     - parameter classifierIDs: A list of the classifier ids to use. "default" is the id of the
-//        built-in classifier.
-//     - parameter threshold: The minimum score a class must have to be displayed in the response.
-//     - parameter language: The language of the output class names. Can be "en" (English), "es"
-//        (Spanish), "ar" (Arabic), or "ja" (Japanese). Classes for which no translation is available
-//        are omitted.
-//     - parameter failure: A function executed if an error occurs.
-//     - parameter success: A function executed with the image classifications.
-//     */
-//    public func classify(
-//        imageFile image: URL,
-//        owners: [String]? = nil,
-//        classifierIDs: [String]? = nil,
-//        threshold: Double? = nil,
-//        language: String? = nil,
-//        failure: ((Error) -> Void)? = nil,
-//        success: @escaping (ClassifiedImages) -> Void)
-//    {
-//        // construct query parameters
-//        var queryParameters = [URLQueryItem]()
-//        queryParameters.append(URLQueryItem(name: "api_key", value: apiKey))
-//        queryParameters.append(URLQueryItem(name: "version", value: version))
-//        
-//        // construct header parameters
-//        var headerParameters = defaultHeaders
-//        if let language = language {
-//            headerParameters["Accept-Language"] = language
-//        }
-//        
-//        // construct visual recognition parameters
-//        var parameters = [String: Any]()
-//        if let owners = owners {
-//            parameters["owners"] = owners
-//        }
-//        if let classifierIDs = classifierIDs {
-//            parameters["classifier_ids"] = classifierIDs
-//        }
-//        if let threshold = threshold {
-//            parameters["threshold"] = threshold
-//        }
-//        guard let json = try? JSON(dictionary: parameters).serialize() else {
-//            failure?(RestError.encodingError)
-//            return
-//        }
-//        
-//        // construct body
-//        let multipartFormData = MultipartFormData()
-//        multipartFormData.append(image, withName: "image_file", mimeType: "application/octet-stream")
-//        // multipartFormData.append(json, withName: "parameters", mimeType: "application/octet-stream", fileName: "parameters.json")
-//        guard let body = try? multipartFormData.toData() else {
-//            failure?(RestError.encodingError)
-//            return
-//        }
-//        
-//        // construct REST request
-//        let request = RestRequest(
-//            method: "POST",
-//            url: serviceURL + "/v3/classify",
-//            credentials: .apiKey,
-//            headerParameters: headerParameters,
-//            acceptType: "application/json",
-//            contentType: multipartFormData.contentType,
-//            queryItems: queryParameters,
-//            messageBody: body
-//        )
-//        
-//        // execute REST request
-//        request.responseObject(dataToError: dataToError) {
-//            (response: RestResponse<ClassifiedImages>) in
-//            switch response.result {
-//            case .success(let classifiedImages): success(classifiedImages)
-//            case .failure(let error): failure?(error)
-//            }
-//        }
-//    }
+    /**
+     Upload and classify an image or multiple images in a compressed (.zip) file.
+     
+     - parameter imageFile: The image file (.jpg or .png) or compressed (.zip) file of images. The
+        total number of images is limited to 20, with a max .zip size of 5 MB.
+     - parameter owners: A list of the classifiers to run. Acceptable values are "IBM" and "me".
+     - parameter classifierIDs: A list of the classifier ids to use. "default" is the id of the
+        built-in classifier.
+     - parameter threshold: The minimum score a class must have to be displayed in the response.
+     - parameter language: The language of the output class names. Can be "en" (English), "es"
+        (Spanish), "ar" (Arabic), or "ja" (Japanese). Classes for which no translation is available
+        are omitted.
+     - parameter failure: A function executed if an error occurs.
+     - parameter success: A function executed with the image classifications.
+     */
+    public func classify(
+        imageFile image: URL,
+        owners: [String]? = nil,
+        classifierIDs: [String]? = nil,
+        threshold: Double? = nil,
+        language: String? = nil,
+        failure: ((Error) -> Void)? = nil,
+        success: @escaping (ClassifiedImages) -> Void)
+    {
+        // construct query parameters
+        var queryParameters = [URLQueryItem]()
+        queryParameters.append(URLQueryItem(name: "api_key", value: apiKey))
+        queryParameters.append(URLQueryItem(name: "version", value: version))
+        
+        // construct header parameters
+        var headerParameters = defaultHeaders
+        if let language = language {
+            headerParameters["Accept-Language"] = language
+        }
+        
+        // construct visual recognition parameters
+        var parameters = [String: Any]()
+        if let owners = owners {
+            parameters["owners"] = owners
+        }
+        if let classifierIDs = classifierIDs {
+            parameters["classifier_ids"] = classifierIDs
+        }
+        if let threshold = threshold {
+            parameters["threshold"] = threshold
+        }
+        guard let json = try? JSON(dictionary: parameters).serialize() else {
+            failure?(RestError.encodingError)
+            return
+        }
+        
+        // construct body
+        let multipartFormData = MultipartFormData()
+        multipartFormData.append(image, withName: "image_file", mimeType: "application/octet-stream")
+        multipartFormData.append(json, withName: "parameters", mimeType: "application/octet-stream", fileName: "parameters.json")
+        guard let body = try? multipartFormData.toData() else {
+            failure?(RestError.encodingError)
+            return
+        }
+        
+        // construct REST request
+        let request = RestRequest(
+            method: "POST",
+            url: serviceURL + "/v3/classify",
+            credentials: .apiKey,
+            headerParameters: headerParameters,
+            acceptType: "application/json",
+            contentType: multipartFormData.contentType,
+            queryItems: queryParameters,
+            messageBody: body
+        )
+        
+        // execute REST request
+        request.responseObject(dataToError: dataToError) {
+            (response: RestResponse<ClassifiedImages>) in
+            switch response.result {
+            case .success(let classifiedImages): success(classifiedImages)
+            case .failure(let error): failure?(error)
+            }
+        }
+    }
     
     /**
      Detect faces in an image at the given URL. Each face is analyzed to estimate age, gender,
@@ -276,59 +271,54 @@ public class VisualRecognition {
         }
     }
     
-    // TODO: The following classify function uploads images to be classified.
-    // Unfortunately, we are seeing an undefined error from the service.
-    // Most likely, there is an issue with the multipart/form data payload.
-    // We will be investigating this issue further and issuing updates soon.
-    
-//    /**
-//     Upload and detect faces in an image or multiple images in a compressed (.zip) file. Each face
-//     is analyzed to estimate age, gender, celebrity name, and more.
-//     
-//     - parameter inImageFile: The image file (.jpg or .png) or compressed (.zip) file of images. The
-//        total number of images is limited to 20, with a max .zip size of 5 MB.
-//     - parameter failure: A function executed if an error occurs.
-//     - parameter success: A function executed with the image classifications.
-//     */
-//    public func detectFaces(
-//        inImageFile image: URL,
-//        failure: ((Error) -> Void)? = nil,
-//        success: @escaping (ImagesWithFaces) -> Void)
-//    {
-//        // construct query parameters
-//        var queryParameters = [URLQueryItem]()
-//        queryParameters.append(URLQueryItem(name: "api_key", value: apiKey))
-//        queryParameters.append(URLQueryItem(name: "version", value: version))
-//
-//        // construct body
-//        let multipartFormData = MultipartFormData()
-//        multipartFormData.append(image, withName: "image_file")
-//        guard let body = try? multipartFormData.toData() else {
-//            failure?(RestError.encodingError)
-//            return
-//        }
-//        
-//        // construct REST request
-//        let request = RestRequest(
-//            method: "POST",
-//            url: serviceURL + "/v3/detect_faces",
-//            credentials: .apiKey,
-//            headerParameters: defaultHeaders,
-//            acceptType: "application/json",
-//            contentType: multipartFormData.contentType,
-//            queryItems: queryParameters,
-//            messageBody: body
-//        )
-//        
-//        // execute REST request
-//        request.responseObject(dataToError: dataToError) {
-//            (response: RestResponse<ImagesWithFaces>) in
-//            switch response.result {
-//            case .success(let classifiedImages): success(classifiedImages)
-//            case .failure(let error): failure?(error)
-//            }
-//        }
-//    }
+    /**
+     Upload and detect faces in an image or multiple images in a compressed (.zip) file. Each face
+     is analyzed to estimate age, gender, celebrity name, and more.
+     
+     - parameter inImageFile: The image file (.jpg or .png) or compressed (.zip) file of images. The
+        total number of images is limited to 20, with a max .zip size of 5 MB.
+     - parameter failure: A function executed if an error occurs.
+     - parameter success: A function executed with the image classifications.
+     */
+    public func detectFaces(
+        inImageFile image: URL,
+        failure: ((Error) -> Void)? = nil,
+        success: @escaping (ImagesWithFaces) -> Void)
+    {
+        // construct query parameters
+        var queryParameters = [URLQueryItem]()
+        queryParameters.append(URLQueryItem(name: "api_key", value: apiKey))
+        queryParameters.append(URLQueryItem(name: "version", value: version))
+
+        // construct body
+        let multipartFormData = MultipartFormData()
+        multipartFormData.append(image, withName: "image_file", mimeType: "application/octet-stream")
+        guard let body = try? multipartFormData.toData() else {
+            failure?(RestError.encodingError)
+            return
+        }
+        
+        // construct REST request
+        let request = RestRequest(
+            method: "POST",
+            url: serviceURL + "/v3/detect_faces",
+            credentials: .apiKey,
+            headerParameters: defaultHeaders,
+            acceptType: "application/json",
+            contentType: multipartFormData.contentType,
+            queryItems: queryParameters,
+            messageBody: body
+        )
+        
+        // execute REST request
+        request.responseObject(dataToError: dataToError) {
+            (response: RestResponse<ImagesWithFaces>) in
+            switch response.result {
+            case .success(let classifiedImages): success(classifiedImages)
+            case .failure(let error): failure?(error)
+            }
+        }
+    }
     
     // MARK: - Custom Classifiers
 
@@ -610,59 +600,50 @@ public class VisualRecognition {
         }
         
     }
+
+    /**
+     Write service input parameters to a temporary JSON file that can be uploaded.
+     
+     - parameter url: An array of image URLs to use.
+     - parameter classifierIDs: An array of classifier ids. "default" is the id of the built-in
+            classifier.
+     - parameter owners: An array of owners. Must be "IBM", "me", or a combination of the two.
+     - parameter showLowConfidence: If true, then the results will include lower-confidence classes.
+     
+     - returns: The URL of a JSON file that includes the given parameters.
+     */
+    private func writeParameters(
+        url: String? = nil,
+        classifierIDs: [String]? = nil,
+        owners: [String]? = nil,
+        showLowConfidence: Bool? = nil) throws
+        -> URL
+    {
+        // construct JSON dictionary
+        var json = [String: Any]()
+        if let url = url {
+            json["url"] = url
+        }
+        if let classifierIDs = classifierIDs {
+            json["classifier_ids"] = classifierIDs
+        }
+        if let owners = owners {
+            json["owners"] = owners
+        }
+        if let showLowConfidence = showLowConfidence {
+            json["show_low_confidence"] = showLowConfidence
+        }
+        
+        // create a globally unique file name in a temporary directory
+        let suffix = "VisualRecognitionParameters.json"
+        let fileName = String(format: "%@_%@", UUID().uuidString, suffix)
+        let directoryURL = NSURL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+        let fileURL = directoryURL.appendingPathComponent(fileName)!
+        
+        // save JSON dictionary to file
+        let data = try JSON(dictionary: json).serialize()
+        try data.write(to: fileURL, options: .atomicWrite)
+        
+        return fileURL
+    }
 }
-
-
-
-// TODO: remove the following unnecessary function, if all tests pass!
-// The classify function requires a file. We used to use this function to actually create
-// a file in the file-system with the given parameters, then pass that file to Alamofire
-// to be encoded in the multipart/form data payload. It's possible that we can avoid creating
-// the file by constructing the multipart/form data payload manually. If it works, then we can
-// remove the code below.
-
-//    /**
-//     Write service input parameters to a temporary JSON file that can be uploaded.
-//     
-//     - parameter url: An array of image URLs to use.
-//     - parameter classifierIDs: An array of classifier ids. "default" is the id of the built-in
-//            classifier.
-//     - parameter owners: An array of owners. Must be "IBM", "me", or a combination of the two.
-//     - parameter showLowConfidence: If true, then the results will include lower-confidence classes.
-//     
-//     - returns: The URL of a JSON file that includes the given parameters.
-//     */
-//    private func writeParameters(
-//        url: String? = nil,
-//        classifierIDs: [String]? = nil,
-//        owners: [String]? = nil,
-//        showLowConfidence: Bool? = nil) throws
-//        -> URL
-//    {
-//        // construct JSON dictionary
-//        var json = [String: Any]()
-//        if let url = url {
-//            json["url"] = url
-//        }
-//        if let classifierIDs = classifierIDs {
-//            json["classifier_ids"] = classifierIDs
-//        }
-//        if let owners = owners {
-//            json["owners"] = owners
-//        }
-//        if let showLowConfidence = showLowConfidence {
-//            json["show_low_confidence"] = showLowConfidence
-//        }
-//        
-//        // create a globally unique file name in a temporary directory
-//        let suffix = "VisualRecognitionParameters.json"
-//        let fileName = String(format: "%@_%@", UUID().uuidString, suffix)
-//        let directoryURL = NSURL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
-//        let fileURL = directoryURL.appendingPathComponent(fileName)!
-//        
-//        // save JSON dictionary to file
-//        let data = try JSON(dictionary: json).serialize()
-//        try data.write(to: fileURL, options: .atomicWrite)
-//        
-//        return fileURL
-//    }

--- a/Tests/VisualRecognitionV3Tests/VisualRecognitionTests.swift
+++ b/Tests/VisualRecognitionV3Tests/VisualRecognitionTests.swift
@@ -40,15 +40,15 @@ class VisualRecognitionTests: XCTestCase {
             ("testClassifyByURL3", testClassifyByURL3),
             ("testClassifyByURL4", testClassifyByURL4),
             ("testClassifyByURL5", testClassifyByURL5),
-//            ("testClassifyImage1", testClassifyImage1), // TODO: add these tests back after fixing upload bug
-//            ("testClassifyImage2", testClassifyImage2),
-//            ("testClassifyImage3", testClassifyImage3),
-//            ("testClassifyImage4", testClassifyImage4),
-//            ("testClassifyImage5", testClassifyImage5),
-//            ("testClassifyImage6", testClassifyImage6),
+            ("testClassifyImage1", testClassifyImage1),
+            ("testClassifyImage2", testClassifyImage2),
+            ("testClassifyImage3", testClassifyImage3),
+            ("testClassifyImage4", testClassifyImage4),
+            ("testClassifyImage5", testClassifyImage5),
+            ("testClassifyImage6", testClassifyImage6),
             ("testDetectFacesByURL", testDetectFacesByURL),
-//            ("testDetectFacesByImage1", testDetectFacesByImage1),
-//            ("testDetectFacesByImage2", testDetectFacesByImage2),
+            ("testDetectFacesByImage1", testDetectFacesByImage1),
+            ("testDetectFacesByImage2", testDetectFacesByImage2),
         ]
     }
     
@@ -724,261 +724,259 @@ class VisualRecognitionTests: XCTestCase {
         waitForExpectations()
     }
     
-//     TODO: Add these tests back when we have updated the classify function.
-//    
-//    /** Classify an uploaded image using the default classifier and all default parameters. */
-//    func testClassifyImage1() {
-//        let description = "Classify an uploaded image using the default classifier."
-//        let expectation = self.expectation(description: description)
-//        
-//        visualRecognition.classify(imageFile: car, failure: failWithError) {
-//            classifiedImages in
-//            
-//            // verify classified images object
-//            XCTAssertNil(classifiedImages.warnings)
-//            XCTAssertEqual(classifiedImages.images.count, 1)
-//            
-//            // verify the image's metadata
-//            let image = classifiedImages.images.first
-//            XCTAssertNil(image?.sourceURL)
-//            XCTAssertNil(image?.resolvedURL)
-//            XCTAssert(image?.image == "car.png")
-//            XCTAssertNil(image?.error)
-//            XCTAssertEqual(image?.classifiers.count, 1)
-//            
-//            // verify the image's classifier
-//            let classifier = image?.classifiers.first
-//            XCTAssertEqual(classifier?.classifierID, "default")
-//            XCTAssertEqual(classifier?.name, "default")
-//            XCTAssertEqual(classifier?.classes.count, 4)
-//            XCTAssertEqual(classifier?.classes.first?.classification, "car")
-//            if let score = classifier?.classes.first?.score {
-//                XCTAssertGreaterThan(score, 0.5)
-//            }
-//            
-//            expectation.fulfill()
-//        }
-//        waitForExpectations()
-//    }
-//    
-//    /** Classify an uploaded image using the default classifier and specifying default parameters. */
-//    func testClassifyImage2() {
-//        let description = "Classify an uploaded image using the default classifier."
-//        let expectation = self.expectation(description: description)
-//        
-//        visualRecognition.classify(
-//            imageFile: car,
-//            owners: ["IBM"],
-//            classifierIDs: ["default"],
-//            threshold: 0.5,
-//            language: "en",
-//            failure: failWithError)
-//        {
-//            classifiedImages in
-//            
-//            // verify classified images object
-//            XCTAssertNil(classifiedImages.warnings)
-//            XCTAssertEqual(classifiedImages.images.count, 1)
-//            
-//            // verify the image's metadata
-//            let image = classifiedImages.images.first
-//            XCTAssertNil(image?.sourceURL)
-//            XCTAssertNil(image?.resolvedURL)
-//            XCTAssert(image?.image == "car.png")
-//            XCTAssertNil(image?.error)
-//            XCTAssertEqual(image?.classifiers.count, 1)
-//            
-//            // verify the image's classifier
-//            let classifier = image?.classifiers.first
-//            XCTAssertEqual(classifier?.classifierID, "default")
-//            XCTAssertEqual(classifier?.name, "default")
-//            XCTAssertEqual(classifier?.classes.count, 4)
-//            XCTAssertEqual(classifier?.classes.first?.classification, "car")
-//            if let score = classifier?.classes.first?.score {
-//                XCTAssertGreaterThan(score, 0.5)
-//            }
-//            
-//            expectation.fulfill()
-//        }
-//        waitForExpectations()
-//    }
-//    
-//    /** Classify an uploaded image using a custom classifier and all default parameters. */
-//    func testClassifyImage3() {
-//        let description = "Classify an uploaded image using a custom classifier."
-//        let expectation = self.expectation(description: description)
-//        
-//        visualRecognition.classify(imageFile: car, classifierIDs: [classifierID!], failure: failWithError) {
-//            classifiedImages in
-//            
-//            // verify classified images object
-//            XCTAssertNil(classifiedImages.warnings)
-//            XCTAssertEqual(classifiedImages.images.count, 1)
-//            
-//            // verify the image's metadata
-//            let image = classifiedImages.images.first
-//            XCTAssertNil(image?.sourceURL)
-//            XCTAssertNil(image?.resolvedURL)
-//            XCTAssert(image?.image == "car.png")
-//            XCTAssertNil(image?.error)
-//            XCTAssertEqual(image?.classifiers.count, 1)
-//            
-//            // verify the image's classifier
-//            let classifier = image?.classifiers.first
-//            XCTAssertEqual(classifier?.classifierID, self.classifierID!)
-//            XCTAssertEqual(classifier?.name, self.classifierName)
-//            XCTAssertEqual(classifier?.classes.count, 1)
-//            XCTAssertEqual(classifier?.classes.first?.classification, "car")
-//            if let score = classifier?.classes.first?.score {
-//                XCTAssertGreaterThan(score, 0.5)
-//            }
-//            
-//            expectation.fulfill()
-//        }
-//        waitForExpectations()
-//    }
-//    
-//    /** Classify an uploaded image using a custom classifier and specifying default parameters. */
-//    func testClassifyImage4() {
-//        let description = "Classify an uploaded image using a custom classifier."
-//        let expectation = self.expectation(description: description)
-//        
-//        visualRecognition.classify(
-//            imageFile: car,
-//            owners: ["me"],
-//            classifierIDs: [classifierID!],
-//            threshold: 0.5,
-//            language: "en",
-//            failure: failWithError)
-//        {
-//            classifiedImages in
-//            
-//            // verify classified images object
-//            XCTAssertNil(classifiedImages.warnings)
-//            XCTAssertEqual(classifiedImages.images.count, 1)
-//            
-//            // verify the image's metadata
-//            let image = classifiedImages.images.first
-//            XCTAssertNil(image?.sourceURL)
-//            XCTAssertNil(image?.resolvedURL)
-//            XCTAssert(image?.image == "car.png")
-//            XCTAssertNil(image?.error)
-//            XCTAssertEqual(image?.classifiers.count, 1)
-//            
-//            // verify the image's classifier
-//            let classifier = image?.classifiers.first
-//            XCTAssertEqual(classifier?.classifierID, self.classifierID!)
-//            XCTAssertEqual(classifier?.name, self.classifierName)
-//            XCTAssertEqual(classifier?.classes.count, 1)
-//            XCTAssertEqual(classifier?.classes.first?.classification, "car")
-//            if let score = classifier?.classes.first?.score {
-//                XCTAssertGreaterThan(score, 0.5)
-//            }
-//            
-//            expectation.fulfill()
-//        }
-//        waitForExpectations()
-//    }
-//    
-//    /** Classify an uploaded image with both the default classifier and a custom classifier. */
-//    func testClassifyImage5() {
-//        let description = "Classify an uploaded image with the default and custom classifiers."
-//        let expectation = self.expectation(description: description)
-//        
-//        visualRecognition.classify(
-//            imageFile: car,
-//            classifierIDs: ["default", classifierID!],
-//            failure: failWithError)
-//        {
-//            classifiedImages in
-//            
-//            // verify classified images object
-//            XCTAssertNil(classifiedImages.warnings)
-//            XCTAssertEqual(classifiedImages.images.count, 1)
-//            
-//            // verify the image's metadata
-//            let image = classifiedImages.images.first
-//            XCTAssertNil(image?.sourceURL)
-//            XCTAssertNil(image?.resolvedURL)
-//            XCTAssert(image?.image == "car.png")
-//            XCTAssertNil(image?.error)
-//            XCTAssertEqual(image?.classifiers.count, 2)
-//            
-//            // verify the image's default classifier
-//            let classifier1 = image?.classifiers.first
-//            XCTAssertEqual(classifier1?.classifierID, "default")
-//            XCTAssertEqual(classifier1?.name, "default")
-//            XCTAssertEqual(classifier1?.classes.count, 4)
-//            XCTAssertEqual(classifier1?.classes.first?.classification, "car")
-//            if let score = classifier1?.classes.first?.score {
-//                XCTAssertGreaterThan(score, 0.5)
-//            }
-//            
-//            // verify the image's custom classifier
-//            let classifier2 = image?.classifiers.last
-//            XCTAssertEqual(classifier2?.classifierID, self.classifierID!)
-//            XCTAssertEqual(classifier2?.name, self.classifierName)
-//            XCTAssertEqual(classifier2?.classes.count, 1)
-//            XCTAssertEqual(classifier2?.classes.first?.classification, "car")
-//            if let score = classifier2?.classes.first?.score {
-//                XCTAssertGreaterThan(score, 0.5)
-//            }
-//            
-//            expectation.fulfill()
-//        }
-//        waitForExpectations()
-//    }
-//    
-//    /** Classify multiple images using a custom classifier. */
-//    func testClassifyImage6() {
-//        let description = "Classify multiple images using a custom classifier."
-//        let expectation = self.expectation(description: description)
-//        
-//        visualRecognition.classify(
-//            imageFile: examplesCars,
-//            classifierIDs: ["default", classifierID!],
-//            failure: failWithError)
-//        {
-//            classifiedImages in
-//            
-//            // verify classified images object
-//            XCTAssertNil(classifiedImages.warnings)
-//            XCTAssertEqual(classifiedImages.images.count, 16)
-//            
-//            for image in classifiedImages.images {
-//                // verify the image's metadata
-//                XCTAssertNil(image.sourceURL)
-//                XCTAssertNil(image.resolvedURL)
-//                XCTAssert(image.image?.hasPrefix("car") == true)
-//                XCTAssertNil(image.error)
-//                XCTAssertEqual(image.classifiers.count, 2)
-//            
-//                // verify the image's default classifier
-//                let classifier1 = image.classifiers.first
-//                XCTAssertEqual(classifier1?.classifierID, "default")
-//                XCTAssertEqual(classifier1?.name, "default")
-//                XCTAssert(classifier1!.classes.count >= 1)
-//                let classification = classifier1?.classes.first?.classification
-//                XCTAssert(classification == "car" || classification == "vehicle")
-//                if let score = classifier1?.classes.first?.score {
-//                    XCTAssertGreaterThan(score, 0.5)
-//                }
-//                
-//                // verify the image's custom classifier
-//                let classifier2 = image.classifiers.last
-//                XCTAssertEqual(classifier2?.classifierID, self.classifierID!)
-//                XCTAssertEqual(classifier2?.name, self.classifierName)
-//                XCTAssertEqual(classifier2?.classes.count, 1)
-//                XCTAssertEqual(classifier2?.classes.first?.classification, "car")
-//                if let score = classifier2?.classes.first?.score {
-//                    XCTAssertGreaterThan(score, 0.5)
-//                }
-//            }
-//            
-//            expectation.fulfill()
-//        }
-//        waitForExpectations()
-//    }
+    /** Classify an uploaded image using the default classifier and all default parameters. */
+    func testClassifyImage1() {
+        let description = "Classify an uploaded image using the default classifier."
+        let expectation = self.expectation(description: description)
+        
+        visualRecognition.classify(imageFile: car, failure: failWithError) {
+            classifiedImages in
+            
+            // verify classified images object
+            XCTAssertNil(classifiedImages.warnings)
+            XCTAssertEqual(classifiedImages.images.count, 1)
+            
+            // verify the image's metadata
+            let image = classifiedImages.images.first
+            XCTAssertNil(image?.sourceURL)
+            XCTAssertNil(image?.resolvedURL)
+            XCTAssert(image?.image == "car.png")
+            XCTAssertNil(image?.error)
+            XCTAssertEqual(image?.classifiers.count, 1)
+            
+            // verify the image's classifier
+            let classifier = image?.classifiers.first
+            XCTAssertEqual(classifier?.classifierID, "default")
+            XCTAssertEqual(classifier?.name, "default")
+            XCTAssertEqual(classifier?.classes.count, 4)
+            XCTAssertEqual(classifier?.classes.first?.classification, "car")
+            if let score = classifier?.classes.first?.score {
+                XCTAssertGreaterThan(score, 0.5)
+            }
+            
+            expectation.fulfill()
+        }
+        waitForExpectations()
+    }
+    
+    /** Classify an uploaded image using the default classifier and specifying default parameters. */
+    func testClassifyImage2() {
+        let description = "Classify an uploaded image using the default classifier."
+        let expectation = self.expectation(description: description)
+        
+        visualRecognition.classify(
+            imageFile: car,
+            owners: ["IBM"],
+            classifierIDs: ["default"],
+            threshold: 0.5,
+            language: "en",
+            failure: failWithError)
+        {
+            classifiedImages in
+            
+            // verify classified images object
+            XCTAssertNil(classifiedImages.warnings)
+            XCTAssertEqual(classifiedImages.images.count, 1)
+            
+            // verify the image's metadata
+            let image = classifiedImages.images.first
+            XCTAssertNil(image?.sourceURL)
+            XCTAssertNil(image?.resolvedURL)
+            XCTAssert(image?.image == "car.png")
+            XCTAssertNil(image?.error)
+            XCTAssertEqual(image?.classifiers.count, 1)
+            
+            // verify the image's classifier
+            let classifier = image?.classifiers.first
+            XCTAssertEqual(classifier?.classifierID, "default")
+            XCTAssertEqual(classifier?.name, "default")
+            XCTAssertEqual(classifier?.classes.count, 4)
+            XCTAssertEqual(classifier?.classes.first?.classification, "car")
+            if let score = classifier?.classes.first?.score {
+                XCTAssertGreaterThan(score, 0.5)
+            }
+            
+            expectation.fulfill()
+        }
+        waitForExpectations()
+    }
+    
+    /** Classify an uploaded image using a custom classifier and all default parameters. */
+    func testClassifyImage3() {
+        let description = "Classify an uploaded image using a custom classifier."
+        let expectation = self.expectation(description: description)
+        
+        visualRecognition.classify(imageFile: car, classifierIDs: [classifierID!], failure: failWithError) {
+            classifiedImages in
+            
+            // verify classified images object
+            XCTAssertNil(classifiedImages.warnings)
+            XCTAssertEqual(classifiedImages.images.count, 1)
+            
+            // verify the image's metadata
+            let image = classifiedImages.images.first
+            XCTAssertNil(image?.sourceURL)
+            XCTAssertNil(image?.resolvedURL)
+            XCTAssert(image?.image == "car.png")
+            XCTAssertNil(image?.error)
+            XCTAssertEqual(image?.classifiers.count, 1)
+            
+            // verify the image's classifier
+            let classifier = image?.classifiers.first
+            XCTAssertEqual(classifier?.classifierID, self.classifierID!)
+            XCTAssertEqual(classifier?.name, self.classifierName)
+            XCTAssertEqual(classifier?.classes.count, 1)
+            XCTAssertEqual(classifier?.classes.first?.classification, "car")
+            if let score = classifier?.classes.first?.score {
+                XCTAssertGreaterThan(score, 0.5)
+            }
+            
+            expectation.fulfill()
+        }
+        waitForExpectations()
+    }
+    
+    /** Classify an uploaded image using a custom classifier and specifying default parameters. */
+    func testClassifyImage4() {
+        let description = "Classify an uploaded image using a custom classifier."
+        let expectation = self.expectation(description: description)
+        
+        visualRecognition.classify(
+            imageFile: car,
+            owners: ["me"],
+            classifierIDs: [classifierID!],
+            threshold: 0.5,
+            language: "en",
+            failure: failWithError)
+        {
+            classifiedImages in
+            
+            // verify classified images object
+            XCTAssertNil(classifiedImages.warnings)
+            XCTAssertEqual(classifiedImages.images.count, 1)
+            
+            // verify the image's metadata
+            let image = classifiedImages.images.first
+            XCTAssertNil(image?.sourceURL)
+            XCTAssertNil(image?.resolvedURL)
+            XCTAssert(image?.image == "car.png")
+            XCTAssertNil(image?.error)
+            XCTAssertEqual(image?.classifiers.count, 1)
+            
+            // verify the image's classifier
+            let classifier = image?.classifiers.first
+            XCTAssertEqual(classifier?.classifierID, self.classifierID!)
+            XCTAssertEqual(classifier?.name, self.classifierName)
+            XCTAssertEqual(classifier?.classes.count, 1)
+            XCTAssertEqual(classifier?.classes.first?.classification, "car")
+            if let score = classifier?.classes.first?.score {
+                XCTAssertGreaterThan(score, 0.5)
+            }
+            
+            expectation.fulfill()
+        }
+        waitForExpectations()
+    }
+    
+    /** Classify an uploaded image with both the default classifier and a custom classifier. */
+    func testClassifyImage5() {
+        let description = "Classify an uploaded image with the default and custom classifiers."
+        let expectation = self.expectation(description: description)
+        
+        visualRecognition.classify(
+            imageFile: car,
+            classifierIDs: ["default", classifierID!],
+            failure: failWithError)
+        {
+            classifiedImages in
+            
+            // verify classified images object
+            XCTAssertNil(classifiedImages.warnings)
+            XCTAssertEqual(classifiedImages.images.count, 1)
+            
+            // verify the image's metadata
+            let image = classifiedImages.images.first
+            XCTAssertNil(image?.sourceURL)
+            XCTAssertNil(image?.resolvedURL)
+            XCTAssert(image?.image == "car.png")
+            XCTAssertNil(image?.error)
+            XCTAssertEqual(image?.classifiers.count, 2)
+            
+            // verify the image's default classifier
+            let classifier1 = image?.classifiers.first
+            XCTAssertEqual(classifier1?.classifierID, "default")
+            XCTAssertEqual(classifier1?.name, "default")
+            XCTAssertEqual(classifier1?.classes.count, 4)
+            XCTAssertEqual(classifier1?.classes.first?.classification, "car")
+            if let score = classifier1?.classes.first?.score {
+                XCTAssertGreaterThan(score, 0.5)
+            }
+            
+            // verify the image's custom classifier
+            let classifier2 = image?.classifiers.last
+            XCTAssertEqual(classifier2?.classifierID, self.classifierID!)
+            XCTAssertEqual(classifier2?.name, self.classifierName)
+            XCTAssertEqual(classifier2?.classes.count, 1)
+            XCTAssertEqual(classifier2?.classes.first?.classification, "car")
+            if let score = classifier2?.classes.first?.score {
+                XCTAssertGreaterThan(score, 0.5)
+            }
+            
+            expectation.fulfill()
+        }
+        waitForExpectations()
+    }
+    
+    /** Classify multiple images using a custom classifier. */
+    func testClassifyImage6() {
+        let description = "Classify multiple images using a custom classifier."
+        let expectation = self.expectation(description: description)
+        
+        visualRecognition.classify(
+            imageFile: examplesCars,
+            classifierIDs: ["default", classifierID!],
+            failure: failWithError)
+        {
+            classifiedImages in
+            
+            // verify classified images object
+            XCTAssertNil(classifiedImages.warnings)
+            XCTAssertEqual(classifiedImages.images.count, 16)
+            
+            for image in classifiedImages.images {
+                // verify the image's metadata
+                XCTAssertNil(image.sourceURL)
+                XCTAssertNil(image.resolvedURL)
+                XCTAssert(image.image?.hasPrefix("car") == true)
+                XCTAssertNil(image.error)
+                XCTAssertEqual(image.classifiers.count, 2)
+            
+                // verify the image's default classifier
+                let classifier1 = image.classifiers.first
+                XCTAssertEqual(classifier1?.classifierID, "default")
+                XCTAssertEqual(classifier1?.name, "default")
+                XCTAssert(classifier1!.classes.count >= 1)
+                let classification = classifier1?.classes.first?.classification
+                XCTAssert(classification == "car" || classification == "vehicle")
+                if let score = classifier1?.classes.first?.score {
+                    XCTAssertGreaterThan(score, 0.5)
+                }
+                
+                // verify the image's custom classifier
+                let classifier2 = image.classifiers.last
+                XCTAssertEqual(classifier2?.classifierID, self.classifierID!)
+                XCTAssertEqual(classifier2?.name, self.classifierName)
+                XCTAssertEqual(classifier2?.classes.count, 1)
+                XCTAssertEqual(classifier2?.classes.first?.classification, "car")
+                if let score = classifier2?.classes.first?.score {
+                    XCTAssertGreaterThan(score, 0.5)
+                }
+            }
+            
+            expectation.fulfill()
+        }
+        waitForExpectations()
+    }
     
     /** Detect faces by URL. */
     func testDetectFacesByURL() {
@@ -1029,105 +1027,103 @@ class VisualRecognitionTests: XCTestCase {
         waitForExpectations()
     }
     
-//    TODO: Add these tests back when the detectFaces function has been updated.
-//
-//    /** Detect faces in an uploaded image */
-//    func testDetectFacesByImage1() {
-//        let description = "Detect faces in an uploaded image."
-//        let expectation = self.expectation(description: description)
-//        
-//        visualRecognition.detectFaces(inImageFile: obama, failure: failWithError) {
-//            faceImages in
-//            
-//            // verify face images object
-//            XCTAssertEqual(faceImages.imagesProcessed, 1)
-//            XCTAssertNil(faceImages.warnings)
-//            XCTAssertEqual(faceImages.images.count, 1)
-//            
-//            // verify the face image object
-//            let face = faceImages.images.first
-//            XCTAssertEqual(face?.sourceURL, self.obamaURL)
-//            XCTAssertEqual(face?.resolvedURL, self.obamaURL)
-//            XCTAssertNil(face?.image)
-//            XCTAssertNil(face?.error)
-//            XCTAssertEqual(face?.faces.count, 1)
-//            
-//            // verify the age
-//            let age = face?.faces.first?.age
-//            XCTAssertGreaterThanOrEqual(age!.min, 45)
-//            XCTAssertLessThanOrEqual(age!.max, 54)
-//            XCTAssertGreaterThanOrEqual(age!.score, 0.25)
-//            
-//            // verify the face location
-//            let location = face?.faces.first?.location
-//            XCTAssertEqual(location?.height, 229)
-//            XCTAssertEqual(location?.left, 213)
-//            XCTAssertEqual(location?.top, 66)
-//            XCTAssertEqual(location?.width, 189)
-//            
-//            // verify the gender
-//            let gender = face?.faces.first?.gender
-//            XCTAssertEqual(gender!.gender, "MALE")
-//            XCTAssertGreaterThanOrEqual(gender!.score, 0.75)
-//            
-//            // verify the identity
-//            let identity = face?.faces.first?.identity
-//            XCTAssertEqual(identity!.name, "Barack Obama")
-//            XCTAssertGreaterThanOrEqual(identity!.score, 0.75)
-//            
-//            expectation.fulfill()
-//        }
-//        waitForExpectations()
-//    }
-//    
-//    /** Detect faces in uploaded images. */
-//    func testDetectFacesByImage2() {
-//        let description = "Detect faces in uploaded images."
-//        let expectation = self.expectation(description: description)
-//        
-//        visualRecognition.detectFaces(inImageFile: faces, failure: failWithError) {
-//            faceImages in
-//            
-//            // verify face images object
-//            XCTAssertEqual(faceImages.imagesProcessed, 3)
-//            XCTAssertNil(faceImages.warnings)
-//            XCTAssertEqual(faceImages.images.count, 3)
-//            
-//            for image in faceImages.images {
-//                // verify the face image object
-//                XCTAssertNil(image.sourceURL)
-//                XCTAssertNil(image.resolvedURL)
-//                XCTAssert(image.image?.hasPrefix("faces.zip/faces/face") == true)
-//                XCTAssertNil(image.error)
-//                XCTAssertEqual(image.faces.count, 1)
-//                
-//                // verify the age
-//                let age = image.faces.first?.age
-//                XCTAssert(age!.min >= 18)
-//                XCTAssert(age!.max <= 44)
-//                XCTAssert(age!.score >= 0.25)
-//                
-//                // verify the face location
-//                let location = image.faces.first?.location
-//                XCTAssert(location!.height >= 100)
-//                XCTAssert(location!.left >= 30)
-//                XCTAssert(location!.top >= 20)
-//                XCTAssert(location!.width >= 90)
-//                
-//                // verify the gender
-//                let gender = image.faces.first?.gender
-//                XCTAssert(gender!.gender == "MALE")
-//                XCTAssert(gender!.score >= 0.75)
-//                
-//                // verify the identity
-//                if let identity = image.faces.first?.identity {
-//                    XCTAssertEqual(identity.name, "Tiger Woods")
-//                    XCTAssert(identity.score >= 0.75)
-//                }
-//            }
-//            
-//            expectation.fulfill()
-//        }
-//        waitForExpectations()
-//    }
+    /** Detect faces in an uploaded image */
+    func testDetectFacesByImage1() {
+        let description = "Detect faces in an uploaded image."
+        let expectation = self.expectation(description: description)
+        
+        visualRecognition.detectFaces(inImageFile: obama, failure: failWithError) {
+            faceImages in
+            
+            // verify face images object
+            XCTAssertEqual(faceImages.imagesProcessed, 1)
+            XCTAssertNil(faceImages.warnings)
+            XCTAssertEqual(faceImages.images.count, 1)
+            
+            // verify the face image object
+            let face = faceImages.images.first
+            XCTAssertNil(face?.sourceURL)
+            XCTAssertNil(face?.resolvedURL)
+            XCTAssertNotNil(face?.image)
+            XCTAssertNil(face?.error)
+            XCTAssertEqual(face?.faces.count, 1)
+            
+            // verify the age
+            let age = face?.faces.first?.age
+            XCTAssertGreaterThanOrEqual(age!.min!, 45)
+            XCTAssertLessThanOrEqual(age!.max!, 54)
+            XCTAssertGreaterThanOrEqual(age!.score, 0.25)
+            
+            // verify the face location
+            let location = face?.faces.first?.location
+            XCTAssertEqual(location?.height, 229)
+            XCTAssertEqual(location?.left, 213)
+            XCTAssertEqual(location?.top, 66)
+            XCTAssertEqual(location?.width, 189)
+            
+            // verify the gender
+            let gender = face?.faces.first?.gender
+            XCTAssertEqual(gender!.gender, "MALE")
+            XCTAssertGreaterThanOrEqual(gender!.score, 0.75)
+            
+            // verify the identity
+            let identity = face?.faces.first?.identity
+            XCTAssertEqual(identity!.name, "Barack Obama")
+            XCTAssertGreaterThanOrEqual(identity!.score, 0.75)
+            
+            expectation.fulfill()
+        }
+        waitForExpectations()
+    }
+    
+    /** Detect faces in uploaded images. */
+    func testDetectFacesByImage2() {
+        let description = "Detect faces in uploaded images."
+        let expectation = self.expectation(description: description)
+        
+        visualRecognition.detectFaces(inImageFile: faces, failure: failWithError) {
+            faceImages in
+            
+            // verify face images object
+            XCTAssertEqual(faceImages.imagesProcessed, 3)
+            XCTAssertNil(faceImages.warnings)
+            XCTAssertEqual(faceImages.images.count, 3)
+            
+            for image in faceImages.images {
+                // verify the face image object
+                XCTAssertNil(image.sourceURL)
+                XCTAssertNil(image.resolvedURL)
+                XCTAssert(image.image?.hasPrefix("faces.zip/faces/face") == true)
+                XCTAssertNil(image.error)
+                XCTAssertEqual(image.faces.count, 1)
+                
+                // verify the age
+                let age = image.faces.first?.age
+                XCTAssert(age!.min! >= 18)
+                XCTAssert(age!.max! <= 44)
+                XCTAssert(age!.score >= 0.25)
+                
+                // verify the face location
+                let location = image.faces.first?.location
+                XCTAssert(location!.height >= 100)
+                XCTAssert(location!.left >= 30)
+                XCTAssert(location!.top >= 20)
+                XCTAssert(location!.width >= 90)
+                
+                // verify the gender
+                let gender = image.faces.first?.gender
+                XCTAssert(gender!.gender == "MALE")
+                XCTAssert(gender!.score >= 0.75)
+                
+                // verify the identity
+                if let identity = image.faces.first?.identity {
+                    XCTAssertEqual(identity.name, "Tiger Woods")
+                    XCTAssert(identity.score >= 0.75)
+                }
+            }
+            
+            expectation.fulfill()
+        }
+        waitForExpectations()
+    }
 }

--- a/WatsonDeveloperCloud.xcodeproj/project.pbxproj
+++ b/WatsonDeveloperCloud.xcodeproj/project.pbxproj
@@ -765,7 +765,7 @@
 		7AAD66481DCA5D730010481E /* baseball.zip */ = {isa = PBXFileReference; lastKnownFileType = archive.zip; path = baseball.zip; sourceTree = "<group>"; };
 		7AAD66491DCA5D730010481E /* cars.zip */ = {isa = PBXFileReference; lastKnownFileType = archive.zip; path = cars.zip; sourceTree = "<group>"; };
 		7AAD664A1DCA5D730010481E /* trucks.zip */ = {isa = PBXFileReference; lastKnownFileType = archive.zip; path = trucks.zip; sourceTree = "<group>"; };
-		7AAD664C1DCA5D730010481E /* car.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = car.png; sourceTree = "<group>"; };
+		7AAD664C1DCA5D730010481E /* car.png */ = {isa = PBXFileReference; explicitFileType = compiled; path = car.png; sourceTree = "<group>"; };
 		7AAD664D1DCA5D730010481E /* faces.zip */ = {isa = PBXFileReference; lastKnownFileType = archive.zip; path = faces.zip; sourceTree = "<group>"; };
 		7AAD664E1DCA5D730010481E /* obama.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = obama.jpg; sourceTree = "<group>"; };
 		7AAD664F1DCA5D730010481E /* sign.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = sign.jpg; sourceTree = "<group>"; };


### PR DESCRIPTION
This pull request uses a workaround to avoid Xcode optimization for the `car.png` image. With that optimization avoided, it re-enables the functions and tests that upload images to the Visual Recognition service.

All of the Visual Recognition tests passed when executed locally:

![image](https://cloud.githubusercontent.com/assets/1957636/20896512/c718aac6-bae3-11e6-8bed-f510f25c4d9d.png)
