### PR TITLE
Fix range exceeds data length crash

### DIFF
--- a/Source/TextToSpeechV1/TextToSpeech.swift
+++ b/Source/TextToSpeechV1/TextToSpeech.swift
@@ -737,22 +737,22 @@ public class TextToSpeech {
         // [1] http://unusedino.de/ec64/technical/formats/wav.html
         // [2] http://soundfile.sapp.org/doc/WaveFormat/
         
-        let riffHeaderChuckIDOffset = 0
-        let riffHeaderChuckIDSize = 4
-        let riffHeaderChuckSizeOffset = 8
-        let riffHeaderChuckSizeSize = 4
+        let riffHeaderChunkIDOffset = 0
+        let riffHeaderChunkIDSize = 4
+        let riffHeaderChunkSizeOffset = 8
+        let riffHeaderChunkSizeSize = 4
         let riffHeaderSize = 12
 
-        if data.count < riffHeaderSize {
+        guard data.count >= riffHeaderSize else {
             return false
         }
         
-        let riffChunkID = dataToUTF8String(data: data, offset: riffHeaderChuckIDOffset, length: riffHeaderChuckIDSize)
+        let riffChunkID = dataToUTF8String(data: data, offset: riffHeaderChunkIDOffset, length: riffHeaderChunkIDSize)
         guard riffChunkID == "RIFF" else {
             return false
         }
         
-        let riffFormat = dataToUTF8String(data: data, offset: riffHeaderChuckSizeOffset, length: riffHeaderChuckSizeSize)
+        let riffFormat = dataToUTF8String(data: data, offset: riffHeaderChunkSizeOffset, length: riffHeaderChunkSizeSize)
         guard riffFormat == "WAVE" else {
             return false
         }

--- a/Source/TextToSpeechV1/TextToSpeech.swift
+++ b/Source/TextToSpeechV1/TextToSpeech.swift
@@ -736,17 +736,23 @@ public class TextToSpeech {
         // resources for WAV header format:
         // [1] http://unusedino.de/ec64/technical/formats/wav.html
         // [2] http://soundfile.sapp.org/doc/WaveFormat/
+        
+        let riffHeaderChuckIDOffset = 0
+        let riffHeaderChuckIDSize = 4
+        let riffHeaderChuckSizeOffset = 8
+        let riffHeaderChuckSizeSize = 4
+        let riffHeaderSize = 12
 
-        if data.count < 12 {
+        if data.count < riffHeaderSize {
             return false
         }
         
-        let riffChunkID = dataToUTF8String(data: data, offset: 0, length: 4)
+        let riffChunkID = dataToUTF8String(data: data, offset: riffHeaderChuckIDOffset, length: riffHeaderChuckIDSize)
         guard riffChunkID == "RIFF" else {
             return false
         }
         
-        let riffFormat = dataToUTF8String(data: data, offset: 8, length: 4)
+        let riffFormat = dataToUTF8String(data: data, offset: riffHeaderChuckSizeOffset, length: riffHeaderChuckSizeSize)
         guard riffFormat == "WAVE" else {
             return false
         }

--- a/Source/TextToSpeechV1/TextToSpeech.swift
+++ b/Source/TextToSpeechV1/TextToSpeech.swift
@@ -736,6 +736,10 @@ public class TextToSpeech {
         // resources for WAV header format:
         // [1] http://unusedino.de/ec64/technical/formats/wav.html
         // [2] http://soundfile.sapp.org/doc/WaveFormat/
+
+        if data.count < 12 {
+            return false
+        }
         
         let riffChunkID = dataToUTF8String(data: data, offset: 0, length: 4)
         guard riffChunkID == "RIFF" else {


### PR DESCRIPTION
If the data returned on to the TextToSpeech synthesize function is
empty, a crash would occur because there was no length checking.

I have signed the Contributor License Agreement.
